### PR TITLE
fix: My Workspaces toggle now works in demo mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fabric-lens",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fabric-lens",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@azure/msal-browser": "^5.8.0",
         "@azure/msal-react": "^5.3.1",

--- a/src/pages/WorkspacesPage.tsx
+++ b/src/pages/WorkspacesPage.tsx
@@ -11,6 +11,7 @@ import { ExportButton } from '@/components/shared/ExportButton';
 import { exportToCSV } from '@/utils/export';
 import { getCurrentUserEmail } from '@/auth/currentUser';
 import { getMyWorkspaceIds } from '@/utils/myWorkspaces';
+import { isEffectiveDemoMode } from '@/auth/AuthProvider';
 import type { Workspace } from '@/api/types/workspace';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 
@@ -19,18 +20,19 @@ export function WorkspacesPage() {
   const navigate = useNavigate();
   const { workspaces, loading, error, fetchWorkspaces } = useWorkspaceStore();
   const { fetchCapacities, getCapacityById } = useCapacityStore();
-  const { workspaceUsers } = useSecurityStore();
+  const { workspaceUsers, populateDemoUsers } = useSecurityStore();
   const [search, setSearch] = useState('');
   const [myOnly, setMyOnly] = useState(false);
 
   const hasScanned = Object.keys(workspaceUsers).length > 0;
   const userEmail = getCurrentUserEmail();
-  const showToggle = hasScanned;
+  const showToggle = hasScanned || isEffectiveDemoMode();
 
   useEffect(() => {
     void fetchWorkspaces();
     void fetchCapacities();
-  }, [fetchWorkspaces, fetchCapacities]);
+    populateDemoUsers();
+  }, [fetchWorkspaces, fetchCapacities, populateDemoUsers]);
 
   const myWorkspaceIds = useMemo(
     () => (myOnly && userEmail ? getMyWorkspaceIds(userEmail, workspaceUsers) : null),

--- a/src/store/securityStore.test.ts
+++ b/src/store/securityStore.test.ts
@@ -18,6 +18,7 @@ vi.mock('@/api/demo', () => ({
   isDemoMode: false,
   isMsalConfigured: true,
   getMockWorkspaceUsers: () => [],
+  getMockAllWorkspaceUsers: () => ({}),
   getMockGroupMemberCount: () => 0,
   getMockResolvedGroup: () => ({ members: [], memberCount: 0 }),
 }));

--- a/src/store/securityStore.ts
+++ b/src/store/securityStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 import type { WorkspaceUser, ResolvedGroup } from '@/api/types/admin';
 import {
   getMockWorkspaceUsers,
+  getMockAllWorkspaceUsers,
   getMockGroupMemberCount,
   getMockResolvedGroup,
 } from '@/api/demo';
@@ -42,6 +43,7 @@ interface SecurityState {
   checkAdminAccess: () => Promise<void>;
   fetchWorkspaceUsers: (workspaceId: string) => Promise<void>;
   fetchAllWorkspaceUsers: (workspaceIds: string[]) => Promise<FetchResult>;
+  populateDemoUsers: () => void;
   resolveGroupCount: (groupUpn: string, displayName: string) => Promise<void>;
   resolveGroupMembers: (groupUpn: string, displayName: string) => Promise<void>;
 }
@@ -171,6 +173,12 @@ export const useSecurityStore = create<SecurityState>()((set, get) => ({
     }
 
     return { status: 'ok' };
+  },
+
+  populateDemoUsers: () => {
+    if (!isEffectiveDemoMode()) return;
+    if (Object.keys(get().workspaceUsers).length > 0) return;
+    set({ workspaceUsers: getMockAllWorkspaceUsers() });
   },
 
   resolveGroupCount: async (groupUpn: string, displayName: string) => {


### PR DESCRIPTION
## Summary
- Toggle was hidden until a Security scan populated `workspaceUsers`; in demo mode that never auto-runs.
- Even when forced visible, `workspaceUsers` was empty, so filtering returned an empty set.
- Adds `securityStore.populateDemoUsers()` to seed `workspaceUsers` from `getMockAllWorkspaceUsers()` synchronously when in demo mode.
- WorkspacesPage now shows the toggle when `hasScanned || isEffectiveDemoMode()` and calls `populateDemoUsers()` on mount.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run src/store/securityStore.test.ts src/utils/myWorkspaces.test.ts` (7/7 pass)
- [x] `npx vite build` succeeds
- [x] Manual demo-mode verification: toggle visible without scan; All shows 35/35; My workspaces shows 17/35