### PR TITLE
fix(test): enable vitest globals so RTL auto-cleanup runs

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,11 @@ export default defineConfig({
     },
   },
   test: {
+    // Required for @testing-library/react's auto-cleanup, which only registers
+    // itself when a global afterEach exists. Without it, component trees stay
+    // mounted after their test file ends and animation loops (ScoreRing's rAF)
+    // keep scheduling React work past jsdom teardown → "window is not defined".
+    globals: true,
     // e2e/ holds Playwright specs (run via `npm run test:e2e`), not Vitest specs —
     // exclude them so `vitest run` doesn't try to execute test() from @playwright/test.
     exclude: [...configDefaults.exclude, 'e2e/**', '.claude/**'],


### PR DESCRIPTION
## Problem

CI on #41 fails with `ReferenceError: window is not defined` even though all 15 test files and 151 tests pass. Vitest exits 1 on 4 unhandled errors raised after the run:

```
ReferenceError: window is not defined
  ❯ performWorkOnRootViaSchedulerTask react-dom-client.development.js:18936
  ❯ Immediate.performWorkUntilDeadline scheduler.development.js:45
```

## Root cause

Not the dependency bump. `@testing-library/react` registers its automatic `cleanup` only when a global `afterEach` exists:

```js
if (typeof afterEach === 'function') {
  afterEach(() => { cleanup() })
}
```

`test.globals` was never enabled, so that branch never ran and **no component test ever unmounted its tree**. `ScoreRing` animates via `requestAnimationFrame` for 600ms (`SCORE_RING_ANIMATION_MS`) while its tests finish in ~240ms. Left mounted, the loop keeps calling `setState` into a jsdom environment that has already been torn down.

The leak predates #41 — `master` is green by luck. The bump only shifted timing enough to lose the race.

## Fix

Enable `globals: true`. Existing tests import `describe`/`it`/`expect` explicitly and keep working unchanged; no tsconfig `types` entry is needed.

## Verification

The race does not reproduce locally (PR 41 branch passed with and without coverage, and three times with `ScoreRing.test.tsx` in isolation), so the mechanism was proven directly with a temporary probe: render `ScoreRing`, then assert `document.body` is empty in the following test.

- with `globals: true` → both tests pass, tree unmounted
- with it commented out → `AssertionError: expected '<div><div class="relative inline-flex…' to be ''`

The probe was removed before committing.

Against **#41's bumped dependencies**, with this fix applied: lint clean, strict build clean, 151/151 tests pass, no unhandled errors. Playwright e2e was not run locally.

## Follow-up

Once this merges, `@dependabot rebase` on #41 to pick it up.