### PR TITLE
ci: skip Azure SWA deploy for Dependabot PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,7 +78,13 @@ jobs:
   deploy:
     name: Deploy to Azure SWA
     needs: ci
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    # Dependabot runs never receive repo secrets, so the SWA deployment token is
+    # empty and the deploy fails. Skip it rather than granting a deployment token
+    # to runs whose purpose is pulling in third-party package updates. Dependabot
+    # PRs are still gated by the ci job above.
+    if: |
+      github.actor != 'dependabot[bot]' &&
+      (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The `Deploy to Azure SWA` job fails on Dependabot PRs:

```
deployment_token was not provided.
An unknown exception has occurred
```

GitHub deliberately withholds repo secrets from Dependabot-triggered workflow runs, so `secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_LIVELY_GRASS_0FA393E10` evaluates to an empty string.

This was masked until now. `deploy` declares `needs: ci`, and the ci job was failing on #41 for unrelated reasons (see #42), so `deploy` was always skipped. With ci fixed, deploy runs for the first time — and fails on every dep bump from here on.

## Fix

Skip `deploy` when the actor is `dependabot[bot]`.

The alternative is granting the deployment token to Dependabot via Dependabot-scoped secrets. That hands a deployment credential to exactly the runs whose purpose is pulling in third-party package updates, which is the wrong trade for a preview URL on a lockfile bump.

Dependabot PRs remain gated by the `ci` job (audit → lint → strict build → tests → e2e), which is the required status check. Nothing about the merge gate weakens.

## Verification

- workflow YAML parses; `jobs` still resolves to `ci`, `deploy`, `close_pull_request_job`
- `deploy.if` evaluates to the intended condition
- deploy behaviour on `push` to master and on human PRs is unchanged