### PR TITLE
feat(items): recognize all GA Fabric item types with map-driven colors

### DIFF
--- a/src/api/demo.ts
+++ b/src/api/demo.ts
@@ -464,7 +464,7 @@ const itemsMap: Record<string, Item[]> = {
     { id: 'item-5', displayName: 'Forecast Notebook', description: 'ML-based sales forecasting', type: 'Notebook', workspaceId: 'ws-1', tags: [TAG_APPROVED] },
     { id: 'item-6', displayName: 'Sales Dashboard', description: 'Executive overview', type: 'Dashboard', workspaceId: 'ws-1', tags: [TAG_CERTIFIED] },
     { id: 'item-7', displayName: 'SQL Endpoint', description: 'Analytics SQL endpoint', type: 'SQLEndpoint', workspaceId: 'ws-1' },
-    { id: 'item-8', displayName: 'Churn Pipeline', description: 'Customer churn prediction', type: 'Pipeline', workspaceId: 'ws-1' },
+    { id: 'item-8', displayName: 'Churn Data Agent', description: 'AI agent for churn analysis Q&A', type: 'DataAgent', workspaceId: 'ws-1' },
   ],
 
   // ws-8: 4/5 = 80% tagged → full tag pts. Total: 110/110 = 100% → A
@@ -498,7 +498,7 @@ const itemsMap: Record<string, Item[]> = {
   // description(10) + capacity(15) + no domain(0) + git(15) + naming(10) + items(10) + dataLayer(10) + reasonable(10) + identity(10) + tags(0) = 90/110 = 82% → B
   // Actually want A. Let me make 5/5 tagged → full pts → 100/110 = 91% → A
   'ws-15': [
-    { id: 'item-150', displayName: 'Sensor Data', description: 'IoT sensor ingestion', type: 'Eventstream', workspaceId: 'ws-15', tags: [TAG_PRODUCTION] },
+    { id: 'item-150', displayName: 'Sensor Eventhouse', description: 'IoT sensor real-time store', type: 'Eventhouse', workspaceId: 'ws-15', tags: [TAG_PRODUCTION] },
     { id: 'item-151', displayName: 'Telemetry Lakehouse', description: 'Device telemetry store', type: 'Lakehouse', workspaceId: 'ws-15', tags: [TAG_PRODUCTION, TAG_CERTIFIED] },
     { id: 'item-152', displayName: 'Device Dashboard', description: 'IoT device monitoring', type: 'Dashboard', workspaceId: 'ws-15', tags: [TAG_APPROVED] },
     { id: 'item-153', displayName: 'Alert Pipeline', description: 'Anomaly detection pipeline', type: 'Pipeline', workspaceId: 'ws-15', tags: [TAG_CERTIFIED] },

--- a/src/api/types/item.ts
+++ b/src/api/types/item.ts
@@ -1,23 +1,73 @@
-export type FabricItemType =
+// Fabric item types. The authoritative enum lives in the Fabric Core REST API
+// ("Items - List Items" > ItemType), which explicitly notes "additional item
+// types may be added over time". So this is an OPEN union: KnownItemType gives
+// autocomplete + documents the current GA catalogue, while `(string & {})` lets
+// any type the API returns flow through without a code change. Display code
+// (ItemTypeBadge, itemTypeToken) degrades unmapped types gracefully.
+// Source: https://learn.microsoft.com/rest/api/fabric/core/items/list-items (2026-07)
+
+export type KnownItemType =
+  // Power BI
   | 'Dashboard'
+  | 'Report'
+  | 'SemanticModel'
+  | 'PaginatedReport'
+  | 'Datamart'
+  // Data engineering
+  | 'Lakehouse'
+  | 'Notebook'
+  | 'SparkJobDefinition'
+  | 'Environment'
+  // Data integration
   | 'DataPipeline'
   | 'Dataflow'
+  | 'CopyJob'
+  | 'MountedDataFactory'
+  | 'ApacheAirflowJob'
+  | 'DataBuildToolJob'
+  // Data warehouse / databases / mirroring
+  | 'Warehouse'
+  | 'WarehouseSnapshot'
+  | 'SQLEndpoint'
+  | 'SQLDatabase'
+  | 'MirroredWarehouse'
+  | 'MirroredDatabase'
+  | 'MirroredAzureDatabricksCatalog'
+  | 'MirroredCatalog'
+  | 'SnowflakeDatabase'
+  | 'CosmosDBDatabase'
+  | 'AzureDatabricksStorage'
+  // Real-time intelligence
+  | 'Eventhouse'
   | 'Eventstream'
   | 'KQLDatabase'
   | 'KQLQueryset'
-  | 'Lakehouse'
+  | 'KQLDashboard'
+  | 'Reflex'
+  | 'EventSchemaSet'
+  | 'AnomalyDetector'
+  // AI / data science
+  | 'DataAgent'
   | 'MLExperiment'
   | 'MLModel'
-  | 'MirroredDatabase'
-  | 'MirroredWarehouse'
-  | 'Notebook'
-  | 'PaginatedReport'
-  | 'Pipeline'
-  | 'Report'
-  | 'SQLEndpoint'
-  | 'SemanticModel'
-  | 'SparkJobDefinition'
-  | 'Warehouse';
+  | 'GraphModel'
+  | 'GraphQuerySet'
+  | 'GraphQLApi'
+  | 'UserDataFunction'
+  // Digital twin / other workloads
+  | 'DigitalTwinBuilder'
+  | 'DigitalTwinBuilderFlow'
+  | 'Map'
+  | 'Ontology'
+  | 'OperationsAgent'
+  | 'VariableLibrary'
+  | 'AppBackend'
+  | 'OrgApp'
+  | 'OrgAppAudience'
+  // Legacy alias kept for existing demo data; not in the current API enum.
+  | 'Pipeline';
+
+export type FabricItemType = KnownItemType | (string & {});
 
 export interface ItemTag {
   id: string;

--- a/src/components/shared/ItemTypeBadge.tsx
+++ b/src/components/shared/ItemTypeBadge.tsx
@@ -1,30 +1,24 @@
 import type { FabricItemType } from '@/api/types/item';
+import { itemTypeToken } from '@/utils/constants';
 
 interface Props {
   type: FabricItemType;
 }
 
-// Pill badges — rounded-full, semibold, uppercase, 0.04em tracking
-// Colors via CSS token variables — auto-adapt to dark mode via .dark {} overrides
-const typeColors: Partial<Record<FabricItemType, string>> = {
-  Lakehouse:    'bg-[var(--item-lakehouse-bg)] text-[var(--item-lakehouse)]',
-  Notebook:     'bg-[var(--item-notebook-bg)] text-[var(--item-notebook)]',
-  Pipeline:     'bg-[var(--item-pipeline-bg)] text-[var(--item-pipeline)]',
-  Report:       'bg-[var(--item-report-bg)] text-[var(--item-report)]',
-  Warehouse:    'bg-[var(--item-warehouse-bg)] text-[var(--item-warehouse)]',
-  SemanticModel:'bg-[var(--item-semantic-model-bg)] text-[var(--item-semantic-model)]',
-  Dashboard:    'bg-[var(--item-dashboard-bg)] text-[var(--item-dashboard)]',
-  DataPipeline: 'bg-[var(--item-pipeline-bg)] text-[var(--item-pipeline)]',
-};
-
-const defaultColors =
-  'bg-[var(--m-surface)] text-[var(--m-text-secondary)]';
-
+// Pill badge — rounded-full, semibold, uppercase, 0.04em tracking.
+// Color is map-driven: itemTypeToken() resolves the type to an --item-* CSS
+// token (mode-aware via .dark {} overrides in index.css); unmapped types get
+// the neutral 'default' token. Inline style is used so the token name can be
+// composed dynamically (Tailwind can't scan a templated var name).
 export function ItemTypeBadge({ type }: Props) {
-  const colors = typeColors[type] ?? defaultColors;
+  const token = itemTypeToken(type);
   return (
     <span
-      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${colors}`}
+      className="inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide"
+      style={{
+        color: `var(--item-${token})`,
+        backgroundColor: `var(--item-${token}-bg)`,
+      }}
     >
       {type}
     </span>

--- a/src/utils/__tests__/itemTypeToken.test.ts
+++ b/src/utils/__tests__/itemTypeToken.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { itemTypeToken } from '../constants';
+
+describe('itemTypeToken', () => {
+  it('maps known workloads to a color token by family', () => {
+    expect(itemTypeToken('Lakehouse')).toBe('lakehouse');
+    expect(itemTypeToken('Report')).toBe('report');
+    // newer GA workloads resolve to a family token, not gray
+    expect(itemTypeToken('DataAgent')).toBe('notebook');
+    expect(itemTypeToken('Eventhouse')).toBe('warehouse');
+  });
+
+  it('falls back to default (gray) for unmapped / future types', () => {
+    expect(itemTypeToken('AppBackend')).toBe('default');
+    expect(itemTypeToken('SomeWorkloadShippedNextYear')).toBe('default');
+  });
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -95,6 +95,68 @@ export const ROLE_COLORS: Record<string, string> = {
 /** Default fallback color for unknown chart categories. */
 export const CHART_FALLBACK_COLOR = '#495057';
 
+// -- Item types --
+
+/**
+ * Maps a Fabric item type to an existing `--item-*` color token suffix (see
+ * index.css for the light/dark values). Related workloads share the eight
+ * established tokens by family; unknown/long-tail types fall through to
+ * 'default' (neutral gray) in {@link itemTypeToken}.
+ * // ponytail: family-reuse of the 8 existing tokens; the makeover (Phase 3
+ * // item 2) replaces this with a per-workload signature palette.
+ */
+const ITEM_TYPE_TOKENS: Record<string, string> = {
+  // Power BI
+  Report: 'report',
+  PaginatedReport: 'report',
+  Dashboard: 'dashboard',
+  SemanticModel: 'semantic-model',
+  Datamart: 'semantic-model',
+  // Data engineering
+  Lakehouse: 'lakehouse',
+  Notebook: 'notebook',
+  SparkJobDefinition: 'notebook',
+  Environment: 'notebook',
+  // Data integration
+  DataPipeline: 'pipeline',
+  Pipeline: 'pipeline',
+  Dataflow: 'pipeline',
+  CopyJob: 'pipeline',
+  MountedDataFactory: 'pipeline',
+  ApacheAirflowJob: 'pipeline',
+  DataBuildToolJob: 'pipeline',
+  // Warehouse / databases / mirroring
+  Warehouse: 'warehouse',
+  WarehouseSnapshot: 'warehouse',
+  SQLEndpoint: 'warehouse',
+  SQLDatabase: 'warehouse',
+  MirroredWarehouse: 'warehouse',
+  MirroredDatabase: 'warehouse',
+  MirroredAzureDatabricksCatalog: 'warehouse',
+  MirroredCatalog: 'warehouse',
+  SnowflakeDatabase: 'warehouse',
+  CosmosDBDatabase: 'warehouse',
+  AzureDatabricksStorage: 'warehouse',
+  // Real-time intelligence
+  Eventhouse: 'warehouse',
+  Eventstream: 'warehouse',
+  KQLDatabase: 'warehouse',
+  KQLQueryset: 'warehouse',
+  KQLDashboard: 'warehouse',
+  Reflex: 'warehouse',
+  // AI / data science
+  DataAgent: 'notebook',
+  MLExperiment: 'notebook',
+  MLModel: 'notebook',
+  GraphModel: 'notebook',
+  GraphQuerySet: 'notebook',
+};
+
+/** Color token suffix for a Fabric item type; 'default' for unmapped types. */
+export function itemTypeToken(type: string): string {
+  return ITEM_TYPE_TOKENS[type] ?? 'default';
+}
+
 /** Shared Recharts tooltip style object (dark themed, uses design tokens). */
 export const CHART_TOOLTIP_STYLE: CSSProperties = {
   backgroundColor: 'var(--m-neutral-900, #16191D)',


### PR DESCRIPTION
First item of the re-scoped Phase 3 (adoption engine): keep the Fabric item-type catalogue current so newer workloads render as first-class, colored badges instead of falling through to gray.

## What
- **Open the type.** `FabricItemType = KnownItemType | (string & {})` so any type the API returns flows through without a code change. Known set grows 19 to ~50, sourced from the Fabric Core "List Items" `ItemType` enum (Data Agent, Eventhouse, KQL Dashboard, GraphQL API, SQL Database, Datamart, and more).
- **Map-driven colors.** Single `itemTypeToken()` source: common workloads reuse the 8 existing `--item-*` tokens by family (mode-aware, no CSS sprawl); long-tail types degrade to a neutral badge instead of gray.
- **Fresher demo.** Two safe retypes surface a Data Agent and an Eventhouse (counts/tags/health scores unchanged).
- **Test.** New unit test for the mapping (known to family, unknown to default).

## Why this shape
The API docs state "additional item types may be added over time," so a closed union is guaranteed to go stale. The open union + graceful default kills that at the root. Colors reuse existing tokens on purpose: the makeover (Phase 3 item 2) redoes the palette, so hand-tuning ~30 new colors now would be thrown away.

## Notes discovered in passing
- The dashboard chart's "Other" slice is a top-12 rollup (`DashboardPage.tsx:169`), not unrecognized types, so this does not change it.
- Chart colors are positional, never linked to item type. Unifying chart and badge color is left for the makeover.

## Verification
`npm run verify` green locally: lint, strict build, coverage floor, 12/12 Playwright e2e (zero console errors on every route).