### PR TITLE
Site makeover: brand, IA, and accessibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ SECURITY_AUDIT.md
 # Local planning docs
 SECURITY_PAGE_PLAN.md
 STRATEGY.md
-TASKS.md
+TASKS*.md
 NEXT.md
 AUTONOMY.md
 docs/superpowers/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -368,7 +368,24 @@ test: add unit tests for health score calculations
 chore: update Tailwind CSS to v3.4
 ```
 
-### 5. Submit a Pull Request
+### 5. Sign Off Your Commits (DCO)
+
+Fabric Lens uses the [Developer Certificate of Origin](https://developercertificate.org/).
+By signing off, you certify that you wrote the contribution or otherwise have the right
+to submit it under the project's MIT license. There is no CLA to sign.
+
+Add a `Signed-off-by` line to every commit with `git commit -s`:
+
+```
+feat: add pipeline monitoring page
+
+Signed-off-by: Jane Doe <jane@example.com>
+```
+
+The name and email must match the ones on the commit. To sign off a branch you already
+committed, use `git rebase --signoff master`.
+
+### 6. Submit a Pull Request
 
 1. Push your branch to your fork.
 2. Open a pull request against the `master` branch of the upstream repository.

--- a/e2e/routes.spec.ts
+++ b/e2e/routes.spec.ts
@@ -2,7 +2,8 @@ import { test, expect } from '@playwright/test';
 import { collectConsoleErrors } from './helpers';
 
 const ROUTES = [
-  '/',
+  '/', // public landing (MarketingShell)
+  '/dashboard',
   '/workspaces',
   '/capacity',
   '/security',

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "fabric-lens",
   "private": true,
   "version": "1.4.0",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { Routes, Route } from 'react-router';
 import { ProtectedRoute } from '@/auth/ProtectedRoute';
 import { AppShell } from '@/components/layout/AppShell';
+import { MarketingShell } from '@/components/layout/MarketingShell';
+import { LandingPage } from '@/components/marketing/LandingPage';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { DashboardPage } from '@/pages/DashboardPage';
 import { WorkspacesPage } from '@/pages/WorkspacesPage';
@@ -14,8 +16,11 @@ import { ReportPage } from '@/pages/ReportPage';
 export function App() {
   return (
     <Routes>
-      {/* Public route — no auth guard */}
-      <Route path="/about" element={<AboutPage />} />
+      {/* Public marketing routes — no auth guard */}
+      <Route element={<MarketingShell />}>
+        <Route path="/" element={<LandingPage />} />
+        <Route path="/about" element={<AboutPage />} />
+      </Route>
 
       {/* Protected routes */}
       <Route
@@ -25,7 +30,7 @@ export function App() {
             <AppShell>
               <ErrorBoundary>
                 <Routes>
-                  <Route path="/" element={<DashboardPage />} />
+                  <Route path="/dashboard" element={<DashboardPage />} />
                   <Route path="/workspaces" element={<WorkspacesPage />} />
                   <Route
                     path="/workspaces/:id"

--- a/src/components/dashboard/HealthGrid.tsx
+++ b/src/components/dashboard/HealthGrid.tsx
@@ -258,7 +258,9 @@ export function HealthGrid({ workspaces, onWorkspaceClick }: HealthGridProps) {
           className="rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-wide transition-colors"
           style={
             activeGrade === null
-              ? { backgroundColor: '#4F46E5', color: '#FFFFFF' }
+              // primary-600 rather than the --m-primary alias: the alias lightens
+              // to primary-400 in dark, which fails AA under white text.
+              ? { backgroundColor: 'var(--m-primary-600)', color: '#FFFFFF' }
               : { backgroundColor: 'var(--m-surface)', color: 'var(--m-text-secondary)' }
           }
         >

--- a/src/components/dashboard/HealthGrid.tsx
+++ b/src/components/dashboard/HealthGrid.tsx
@@ -4,6 +4,8 @@ import {
   HEALTH_GRID_GAP,
   HEALTH_GRID_MAX_TILES,
   HEALTH_GRID_HOVER_SCALE,
+  HEALTH_GRID_STAGGER_STEP_MS,
+  HEALTH_GRID_STAGGER_MAX_MS,
 } from '@/utils/constants';
 
 // Grade ordering: worst → best
@@ -302,15 +304,20 @@ export function HealthGrid({ workspaces, onWorkspaceClick }: HealthGridProps) {
               gap: `${HEALTH_GRID_GAP}px`,
             }}
           >
-            {tiles.map((entry) => (
+            {tiles.map((entry, i) => (
               <button
                 key={entry.id}
+                className="m-tile-in"
                 onClick={() => onWorkspaceClick?.(entry.id)}
                 onMouseMove={(e) => handleMouseMove(e, entry)}
                 onMouseEnter={handleTileEnter}
                 onMouseLeave={handleTileOut}
                 aria-label={`${entry.name} — Grade ${entry.grade}, ${entry.score}%`}
                 style={{
+                  animationDelay: `${Math.min(
+                    i * HEALTH_GRID_STAGGER_STEP_MS,
+                    HEALTH_GRID_STAGGER_MAX_MS,
+                  )}ms`,
                   width: HEALTH_GRID_TILE_SIZE,
                   height: HEALTH_GRID_TILE_SIZE,
                   borderRadius: 6,

--- a/src/components/dashboard/HealthGrid.tsx
+++ b/src/components/dashboard/HealthGrid.tsx
@@ -17,7 +17,7 @@ const GRADE_PRIMARY: Record<Grade, string> = {
   A: '#15803D',
   B: '#4F46E5',
   C: '#B45309',
-  D: '#EA580C',
+  D: '#C2410C',
   F: '#DC2626',
 };
 

--- a/src/components/dashboard/SecurityQuickView.tsx
+++ b/src/components/dashboard/SecurityQuickView.tsx
@@ -158,7 +158,7 @@ export function SecurityQuickView() {
           <button
             onClick={handleLoad}
             disabled={workspaces.length === 0}
-            className="mt-5 inline-flex items-center gap-1.5 rounded-lg bg-[var(--m-primary)] px-3 py-1.5 text-xs font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+            className="mt-5 inline-flex items-center gap-1.5 rounded-lg bg-[var(--m-primary-600)] px-3 py-1.5 text-xs font-semibold text-white transition-opacity hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
           >
             Load security data
           </button>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -131,7 +131,7 @@ export function Header() {
               </>
             ) : (
               <>
-                <div className="flex h-7 w-7 items-center justify-center rounded-full bg-[var(--m-primary)] text-xs font-semibold text-white">
+                <div className="flex h-7 w-7 items-center justify-center rounded-full bg-[var(--m-primary-600)] text-xs font-semibold text-white">
                   {initials ?? '?'}
                 </div>
                 {user && (

--- a/src/components/layout/MarketingShell.tsx
+++ b/src/components/layout/MarketingShell.tsx
@@ -1,0 +1,19 @@
+import { Outlet } from 'react-router';
+import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+
+/**
+ * Public shell for marketing surfaces (landing, about). No sidebar and no auth
+ * guard — these routes must render for signed-out visitors.
+ *
+ * Nav and footer arrive in Task 2.2, which also strips AboutPage's bespoke
+ * header so this shell owns the chrome for both routes.
+ */
+export function MarketingShell() {
+  return (
+    <div className="min-h-screen bg-[var(--m-bg)] text-[var(--m-text)]">
+      <ErrorBoundary>
+        <Outlet />
+      </ErrorBoundary>
+    </div>
+  );
+}

--- a/src/components/layout/MarketingShell.tsx
+++ b/src/components/layout/MarketingShell.tsx
@@ -1,19 +1,28 @@
 import { Outlet } from 'react-router';
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary';
+import { ToastContainer } from '@/components/shared/Toast';
+import { MarketingNav } from '@/components/marketing/MarketingNav';
+import { MarketingFooter } from '@/components/marketing/MarketingFooter';
 
 /**
  * Public shell for marketing surfaces (landing, about). No sidebar and no auth
  * guard — these routes must render for signed-out visitors.
  *
- * Nav and footer arrive in Task 2.2, which also strips AboutPage's bespoke
- * header so this shell owns the chrome for both routes.
+ * ToastContainer is mounted here as well as in AppShell: the toast store is
+ * global, but the renderer is not, so sign-in failures from the public nav
+ * would otherwise never be shown.
  */
 export function MarketingShell() {
   return (
-    <div className="min-h-screen bg-[var(--m-bg)] text-[var(--m-text)]">
+    <div className="flex min-h-screen flex-col bg-[var(--m-bg)] text-[var(--m-text)]">
+      <MarketingNav />
       <ErrorBoundary>
-        <Outlet />
+        <div className="flex-1">
+          <Outlet />
+        </div>
       </ErrorBoundary>
+      <MarketingFooter />
+      <ToastContainer />
     </div>
   );
 }

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -23,7 +23,7 @@ interface NavItem {
 }
 
 const BASE_NAV_ITEMS: Omit<NavItem, 'badge'>[] = [
-  { label: 'Dashboard', path: '/', icon: LayoutDashboard },
+  { label: 'Dashboard', path: '/dashboard', icon: LayoutDashboard },
   { label: 'Workspaces', path: '/workspaces', icon: FolderOpen },
   { label: 'Capacity', path: '/capacity', icon: Gauge },
   { label: 'Security', path: '/security', icon: Shield },
@@ -97,7 +97,6 @@ export function Sidebar() {
           <NavLink
             key={item.path}
             to={item.path}
-            end={item.path === '/'}
             title={collapsed ? item.label : undefined}
             className={({ isActive }) =>
               `flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors duration-[120ms] ${

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -81,7 +81,7 @@ export function Sidebar() {
     >
       {/* Logo */}
       <div className="flex h-14 items-center gap-2 border-b border-[var(--m-border)] px-4">
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[var(--m-primary)] text-sm font-bold text-white">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-[var(--m-primary-600)] text-sm font-bold text-white">
           F
         </div>
         {!collapsed && (
@@ -111,7 +111,7 @@ export function Sidebar() {
               <span className="flex flex-1 items-center justify-between">
                 <span>{item.label}</span>
                 {item.badge && (
-                  <span className="rounded-full bg-[var(--m-primary)] px-1.5 py-0.5 text-[10px] font-semibold text-white">
+                  <span className="rounded-full bg-[var(--m-primary-600)] px-1.5 py-0.5 text-[10px] font-semibold text-white">
                     {item.badge}
                   </span>
                 )}

--- a/src/components/marketing/LandingPage.tsx
+++ b/src/components/marketing/LandingPage.tsx
@@ -1,22 +1,189 @@
+import { useMemo } from 'react';
+import { Link, useNavigate } from 'react-router';
+import { ShieldCheck, Activity, Boxes, Gauge } from 'lucide-react';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import { HealthGrid } from '@/components/dashboard/HealthGrid';
+import { mockWorkspaces, getMockAllWorkspaceItems } from '@/api/demo';
+import { calculateWorkspaceHealth } from '@/utils/healthScore';
+import { GITHUB_URL } from '@/utils/constants';
+
+const VALUE_PROPS = [
+  {
+    icon: ShieldCheck,
+    title: 'Security posture',
+    body: 'Over-permissioned workspaces, org-wide shares, risky tenant settings, and service principal sprawl, surfaced as findings you can act on.',
+  },
+  {
+    icon: Activity,
+    title: 'Health intelligence',
+    body: 'Every workspace scored against nine governance checks, graded A to F, with the quick win named on each one.',
+  },
+  {
+    icon: Boxes,
+    title: 'Inventory',
+    body: 'Workspaces, items, capacities, and domains in one searchable view, exportable to CSV for the client deck.',
+  },
+  {
+    icon: Gauge,
+    title: 'Capacity cost',
+    body: 'SKU sizing and utilization against live Azure retail rates, so the capacity conversation starts from a number.',
+  },
+] as const;
+
+const STEPS = [
+  {
+    title: 'Open it',
+    body: 'No install, no backend, no trial signup. Try the demo tenant first if you want to look before you connect.',
+  },
+  {
+    title: 'Connect your tenant',
+    body: 'Sign in with your work account. Read-only Fabric scopes, requested incrementally, so admin APIs are only consented when you use them.',
+  },
+  {
+    title: 'Read the findings',
+    body: 'Scores, findings, and inventory render in the browser. Export what matters and share the page with the tenant owner.',
+  },
+] as const;
+
+function ValueProps() {
+  return (
+    <section className="mx-auto max-w-6xl px-6 py-20">
+      <h2 className="m-display text-3xl">What it tells you</h2>
+      <div className="mt-10 grid gap-6 sm:grid-cols-2">
+        {VALUE_PROPS.map(({ icon: Icon, title, body }) => (
+          <div
+            key={title}
+            className="rounded-xl border border-[var(--m-border)] bg-[var(--m-surface)] p-6"
+          >
+            <Icon className="h-5 w-5 text-[var(--m-primary)]" />
+            <h3 className="mt-4 text-base font-bold text-[var(--m-text)]">{title}</h3>
+            <p className="mt-2 text-sm leading-relaxed text-[var(--m-text-secondary)]">
+              {body}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function HowItWorks() {
+  return (
+    <section className="border-y border-[var(--m-border)] bg-[var(--m-surface)]">
+      <div className="mx-auto max-w-6xl px-6 py-20">
+        <h2 className="m-display text-3xl">How it works</h2>
+        <ol className="mt-10 grid gap-8 sm:grid-cols-3">
+          {STEPS.map(({ title, body }, i) => (
+            <li key={title}>
+              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-[var(--m-primary-subtle)] text-sm font-bold text-[var(--m-primary)]">
+                {i + 1}
+              </span>
+              <h3 className="mt-4 text-base font-bold text-[var(--m-text)]">{title}</h3>
+              <p className="mt-2 text-sm leading-relaxed text-[var(--m-text-secondary)]">
+                {body}
+              </p>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+}
 
 /**
- * Public landing page at `/`. Hero, value props, and closing CTA land in
- * Task 2.3 — this is the structural placeholder that lets the route split
- * ship on its own.
+ * Public landing page at `/`.
+ *
+ * The product glimpse reuses the real `HealthGrid` over the demo tenant, scored
+ * by the real `calculateWorkspaceHealth`, so the visual on the landing page is
+ * the same component and the same math a visitor meets on the dashboard.
  */
 export function LandingPage() {
   // Empty string yields the bare base title, not "fabric-lens | fabric-lens".
   useDocumentTitle('');
+  const navigate = useNavigate();
+
+  const glimpse = useMemo(() => {
+    const itemsByWorkspace = getMockAllWorkspaceItems();
+    return mockWorkspaces.map((ws) => {
+      const health = calculateWorkspaceHealth(ws, itemsByWorkspace[ws.id] ?? []);
+      return {
+        id: ws.id,
+        name: ws.displayName,
+        score: health.percentage,
+        grade: health.grade,
+        topFailedCheck: health.checks.find((c) => !c.passed)?.detail,
+      };
+    });
+  }, []);
 
   return (
-    <main className="mx-auto max-w-5xl px-6 py-24">
-      {/* m-display-hero is size-only; m-display carries weight 800 + tracking. */}
-      <h1 className="m-display m-display-hero">fabric-lens</h1>
-      <p className="mt-4 max-w-2xl text-lg text-[var(--m-text-secondary)]">
-        Governance, health intelligence, and inventory management for Microsoft
-        Fabric tenants.
-      </p>
+    <main>
+      {/* Hero */}
+      <section className="mx-auto max-w-6xl px-6 pt-20 pb-16 sm:pt-28">
+        <h1 className="m-display m-display-hero max-w-3xl">
+          Know what your Fabric tenant is{' '}
+          <span className="m-gradient-text">actually doing</span>
+        </h1>
+        <p className="mt-6 max-w-2xl text-lg leading-relaxed text-[var(--m-text-secondary)]">
+          Governance, security posture, and health intelligence for Microsoft
+          Fabric. It runs entirely in your browser against the Fabric REST APIs,
+          so tenant data never passes through anyone else's servers.
+        </p>
+
+        <div className="mt-10 flex flex-wrap items-center gap-4">
+          <Link
+            to="/dashboard"
+            className="rounded-full px-6 py-3 text-sm font-semibold text-white [background-image:var(--m-gradient-brand)] transition-opacity duration-[120ms] hover:opacity-90"
+          >
+            Try the demo
+          </Link>
+          <a
+            href={GITHUB_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="rounded-full border border-[var(--m-border)] px-6 py-3 text-sm font-semibold text-[var(--m-text)] transition-colors duration-[120ms] hover:bg-[var(--m-surface-hover)]"
+          >
+            View the source
+          </a>
+        </div>
+
+        {/* Product glimpse */}
+        <div className="mt-16">
+          <HealthGrid
+            workspaces={glimpse}
+            onWorkspaceClick={() => navigate('/dashboard')}
+          />
+          <p className="mt-3 text-xs text-[var(--m-text-tertiary)]">
+            Live component, demo tenant. Every tile is a workspace graded on the
+            same checks your tenant would be.
+          </p>
+        </div>
+      </section>
+
+      <ValueProps />
+      <HowItWorks />
+
+      {/* Closing CTA */}
+      <section className="mx-auto max-w-6xl px-6 py-24 text-center">
+        <h2 className="m-display text-3xl">See your own tenant</h2>
+        <p className="mx-auto mt-4 max-w-xl text-[var(--m-text-secondary)]">
+          Free and open source. Nothing to deploy, nothing to configure.
+        </p>
+        <div className="mt-8 flex flex-wrap justify-center gap-4">
+          <Link
+            to="/dashboard"
+            className="rounded-full px-6 py-3 text-sm font-semibold text-white [background-image:var(--m-gradient-brand)] transition-opacity duration-[120ms] hover:opacity-90"
+          >
+            Try the demo
+          </Link>
+          <Link
+            to="/about"
+            className="rounded-full border border-[var(--m-border)] px-6 py-3 text-sm font-semibold text-[var(--m-text)] transition-colors duration-[120ms] hover:bg-[var(--m-surface-hover)]"
+          >
+            How scoring works
+          </Link>
+        </div>
+      </section>
     </main>
   );
 }

--- a/src/components/marketing/LandingPage.tsx
+++ b/src/components/marketing/LandingPage.tsx
@@ -120,17 +120,23 @@ export function LandingPage() {
     <main>
       {/* Hero */}
       <section className="mx-auto max-w-6xl px-6 pt-20 pb-16 sm:pt-28">
-        <h1 className="m-display m-display-hero max-w-3xl">
+        <h1 className="m-display m-display-hero m-enter-up max-w-3xl">
           Know what your Fabric tenant is{' '}
           <span className="m-gradient-text">actually doing</span>
         </h1>
-        <p className="mt-6 max-w-2xl text-lg leading-relaxed text-[var(--m-text-secondary)]">
+        <p
+          className="m-enter-up mt-6 max-w-2xl text-lg leading-relaxed text-[var(--m-text-secondary)]"
+          style={{ animationDelay: '80ms' }}
+        >
           Governance, security posture, and health intelligence for Microsoft
           Fabric. It runs entirely in your browser against the Fabric REST APIs,
           so tenant data never passes through anyone else's servers.
         </p>
 
-        <div className="mt-10 flex flex-wrap items-center gap-4">
+        <div
+          className="m-enter-up mt-10 flex flex-wrap items-center gap-4"
+          style={{ animationDelay: '160ms' }}
+        >
           <Link
             to="/dashboard"
             className="m-cta"

--- a/src/components/marketing/LandingPage.tsx
+++ b/src/components/marketing/LandingPage.tsx
@@ -1,0 +1,22 @@
+import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+
+/**
+ * Public landing page at `/`. Hero, value props, and closing CTA land in
+ * Task 2.3 — this is the structural placeholder that lets the route split
+ * ship on its own.
+ */
+export function LandingPage() {
+  // Empty string yields the bare base title, not "fabric-lens | fabric-lens".
+  useDocumentTitle('');
+
+  return (
+    <main className="mx-auto max-w-5xl px-6 py-24">
+      {/* m-display-hero is size-only; m-display carries weight 800 + tracking. */}
+      <h1 className="m-display m-display-hero">fabric-lens</h1>
+      <p className="mt-4 max-w-2xl text-lg text-[var(--m-text-secondary)]">
+        Governance, health intelligence, and inventory management for Microsoft
+        Fabric tenants.
+      </p>
+    </main>
+  );
+}

--- a/src/components/marketing/LandingPage.tsx
+++ b/src/components/marketing/LandingPage.tsx
@@ -133,7 +133,7 @@ export function LandingPage() {
         <div className="mt-10 flex flex-wrap items-center gap-4">
           <Link
             to="/dashboard"
-            className="rounded-full px-6 py-3 text-sm font-semibold text-white [background-image:var(--m-gradient-brand)] transition-opacity duration-[120ms] hover:opacity-90"
+            className="m-cta"
           >
             Try the demo
           </Link>
@@ -141,7 +141,7 @@ export function LandingPage() {
             href={GITHUB_URL}
             target="_blank"
             rel="noreferrer"
-            className="rounded-full border border-[var(--m-border)] px-6 py-3 text-sm font-semibold text-[var(--m-text)] transition-colors duration-[120ms] hover:bg-[var(--m-surface-hover)]"
+            className="m-cta-ghost"
           >
             View the source
           </a>
@@ -172,13 +172,13 @@ export function LandingPage() {
         <div className="mt-8 flex flex-wrap justify-center gap-4">
           <Link
             to="/dashboard"
-            className="rounded-full px-6 py-3 text-sm font-semibold text-white [background-image:var(--m-gradient-brand)] transition-opacity duration-[120ms] hover:opacity-90"
+            className="m-cta"
           >
             Try the demo
           </Link>
           <Link
             to="/about"
-            className="rounded-full border border-[var(--m-border)] px-6 py-3 text-sm font-semibold text-[var(--m-text)] transition-colors duration-[120ms] hover:bg-[var(--m-surface-hover)]"
+            className="m-cta-ghost"
           >
             How scoring works
           </Link>

--- a/src/components/marketing/MarketingFooter.tsx
+++ b/src/components/marketing/MarketingFooter.tsx
@@ -1,0 +1,46 @@
+import { Link } from 'react-router';
+import { GITHUB_URL } from '@/utils/constants';
+
+/**
+ * Footer for the public marketing shell.
+ *
+ * The privacy line states what is architecturally true today: fabric-lens is a
+ * client-side SPA that calls Fabric APIs straight from the browser, so tenant
+ * data never reaches a server of ours. Revisit this wording if the Cloudflare
+ * analytics beacon lands on the public shell.
+ */
+export function MarketingFooter() {
+  return (
+    <footer className="border-t border-[var(--m-border)] px-6 py-10">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
+        <div className="max-w-md">
+          <span className="m-display text-base">
+            fabric-<span className="m-gradient-text">lens</span>
+          </span>
+          <p className="mt-2 text-sm text-[var(--m-text-secondary)]">
+            Runs entirely in your browser. Tenant data is read directly from the
+            Fabric APIs and never passes through our servers.
+          </p>
+        </div>
+
+        <nav className="flex flex-col gap-2 text-sm">
+          <Link
+            to="/about"
+            className="text-[var(--m-text-secondary)] transition-colors duration-[120ms] hover:text-[var(--m-text)]"
+          >
+            About
+          </Link>
+          <a
+            href={GITHUB_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="text-[var(--m-text-secondary)] transition-colors duration-[120ms] hover:text-[var(--m-text)]"
+          >
+            Source on GitHub
+          </a>
+          <span className="text-[var(--m-text-tertiary)]">MIT licensed</span>
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/marketing/MarketingNav.tsx
+++ b/src/components/marketing/MarketingNav.tsx
@@ -19,7 +19,7 @@ export function MarketingNav() {
   return (
     <header className="sticky top-0 z-40 border-b border-[var(--m-border)] bg-[var(--m-bg)]/90 backdrop-blur">
       <nav className="mx-auto flex max-w-6xl items-center gap-6 px-6 py-4">
-        <Link to="/" className="m-display text-lg">
+        <Link to="/" className="m-display whitespace-nowrap text-lg">
           fabric-<span className="m-gradient-text">lens</span>
         </Link>
 
@@ -55,7 +55,7 @@ export function MarketingNav() {
           {isAuthenticated ? (
             <Link
               to="/dashboard"
-              className="m-cta px-4 py-2"
+              className="m-cta whitespace-nowrap px-4 py-2"
             >
               Open dashboard
             </Link>
@@ -70,13 +70,13 @@ export function MarketingNav() {
                     );
                   });
                 }}
-                className="text-sm font-medium text-[var(--m-text-secondary)] transition-colors duration-[120ms] hover:text-[var(--m-text)]"
+                className="whitespace-nowrap text-sm font-medium text-[var(--m-text-secondary)] transition-colors duration-[120ms] hover:text-[var(--m-text)]"
               >
                 Sign in
               </button>
               <Link
                 to="/dashboard"
-                className="m-cta px-4 py-2"
+                className="m-cta whitespace-nowrap px-4 py-2"
               >
                 Try the demo
               </Link>

--- a/src/components/marketing/MarketingNav.tsx
+++ b/src/components/marketing/MarketingNav.tsx
@@ -1,6 +1,8 @@
 import { Link } from 'react-router';
+import { Sun, Moon } from 'lucide-react';
 import { useAuth } from '@/auth/useAuth';
 import { useToastStore } from '@/components/shared/Toast';
+import { useUiStore } from '@/store/uiStore';
 import { GITHUB_URL } from '@/utils/constants';
 
 /**
@@ -11,6 +13,8 @@ import { GITHUB_URL } from '@/utils/constants';
 export function MarketingNav() {
   const { isAuthenticated, login } = useAuth();
   const addToast = useToastStore((s) => s.addToast);
+  const theme = useUiStore((s) => s.theme);
+  const setTheme = useUiStore((s) => s.setTheme);
 
   return (
     <header className="sticky top-0 z-40 border-b border-[var(--m-border)] bg-[var(--m-bg)]/90 backdrop-blur">
@@ -34,6 +38,19 @@ export function MarketingNav() {
           >
             GitHub
           </a>
+
+          <button
+            onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+            title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+            aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+            className="rounded-lg p-2 text-[var(--m-text-tertiary)] transition-colors duration-[120ms] hover:bg-[var(--m-surface-hover)] hover:text-[var(--m-text-secondary)]"
+          >
+            {theme === 'dark' ? (
+              <Sun className="h-4 w-4" />
+            ) : (
+              <Moon className="h-4 w-4" />
+            )}
+          </button>
 
           {isAuthenticated ? (
             <Link

--- a/src/components/marketing/MarketingNav.tsx
+++ b/src/components/marketing/MarketingNav.tsx
@@ -1,0 +1,72 @@
+import { Link } from 'react-router';
+import { useAuth } from '@/auth/useAuth';
+import { useToastStore } from '@/components/shared/Toast';
+import { GITHUB_URL } from '@/utils/constants';
+
+/**
+ * Top nav for the public marketing shell. No sidebar, no auth guard — this
+ * renders for signed-out visitors, so every control has to work without a
+ * session.
+ */
+export function MarketingNav() {
+  const { isAuthenticated, login } = useAuth();
+  const addToast = useToastStore((s) => s.addToast);
+
+  return (
+    <header className="sticky top-0 z-40 border-b border-[var(--m-border)] bg-[var(--m-bg)]/90 backdrop-blur">
+      <nav className="mx-auto flex max-w-6xl items-center gap-6 px-6 py-4">
+        <Link to="/" className="m-display text-lg">
+          fabric-<span className="m-gradient-text">lens</span>
+        </Link>
+
+        <div className="ml-auto flex items-center gap-5">
+          <Link
+            to="/about"
+            className="hidden text-sm text-[var(--m-text-secondary)] transition-colors duration-[120ms] hover:text-[var(--m-text)] sm:inline"
+          >
+            About
+          </Link>
+          <a
+            href={GITHUB_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="hidden text-sm text-[var(--m-text-secondary)] transition-colors duration-[120ms] hover:text-[var(--m-text)] sm:inline"
+          >
+            GitHub
+          </a>
+
+          {isAuthenticated ? (
+            <Link
+              to="/dashboard"
+              className="rounded-full px-4 py-2 text-sm font-semibold text-white [background-image:var(--m-gradient-brand)] transition-opacity duration-[120ms] hover:opacity-90"
+            >
+              Open dashboard
+            </Link>
+          ) : (
+            <>
+              <button
+                onClick={() => {
+                  login().catch(() => {
+                    addToast(
+                      'error',
+                      'Sign-in failed. Check that your browser allows pop-ups for this site and try again.',
+                    );
+                  });
+                }}
+                className="text-sm font-medium text-[var(--m-text-secondary)] transition-colors duration-[120ms] hover:text-[var(--m-text)]"
+              >
+                Sign in
+              </button>
+              <Link
+                to="/dashboard"
+                className="rounded-full px-4 py-2 text-sm font-semibold text-white [background-image:var(--m-gradient-brand)] transition-opacity duration-[120ms] hover:opacity-90"
+              >
+                Try the demo
+              </Link>
+            </>
+          )}
+        </div>
+      </nav>
+    </header>
+  );
+}

--- a/src/components/marketing/MarketingNav.tsx
+++ b/src/components/marketing/MarketingNav.tsx
@@ -55,7 +55,7 @@ export function MarketingNav() {
           {isAuthenticated ? (
             <Link
               to="/dashboard"
-              className="rounded-full px-4 py-2 text-sm font-semibold text-white [background-image:var(--m-gradient-brand)] transition-opacity duration-[120ms] hover:opacity-90"
+              className="m-cta px-4 py-2"
             >
               Open dashboard
             </Link>
@@ -76,7 +76,7 @@ export function MarketingNav() {
               </button>
               <Link
                 to="/dashboard"
-                className="rounded-full px-4 py-2 text-sm font-semibold text-white [background-image:var(--m-gradient-brand)] transition-opacity duration-[120ms] hover:opacity-90"
+                className="m-cta px-4 py-2"
               >
                 Try the demo
               </Link>

--- a/src/components/security/SecurityAreaSection.tsx
+++ b/src/components/security/SecurityAreaSection.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from 'react';
+import { ChevronDown, CheckCircle2 } from 'lucide-react';
+import type { SecurityArea } from '@/utils/securityAreas';
+
+interface Props {
+  area: SecurityArea;
+  /**
+   * Areas start closed: the posture card and findings above them already answer
+   * "what is wrong", and the summary row carries every count, so opening one is
+   * a choice to see the evidence rather than a way to discover a problem.
+   */
+  defaultOpen?: boolean;
+  children: ReactNode;
+}
+
+/**
+ * One drill-in area on the Security page: a headline count and the question the
+ * area answers, expanding to the existing panels for that area.
+ *
+ * Built on native `<details>`, so open/close state, keyboard operation, and
+ * in-page find all work without a line of JS.
+ */
+export function SecurityAreaSection({ area, defaultOpen, children }: Props) {
+  const clean = area.count === 0;
+
+  return (
+    <details
+      open={defaultOpen}
+      className="group overflow-hidden rounded-xl border border-[var(--m-border)] bg-[var(--m-bg)]"
+    >
+      <summary className="flex cursor-pointer list-none items-center gap-4 p-4 transition-colors hover:bg-[var(--m-surface-hover)]">
+        <div className="min-w-0 flex-1">
+          <h2 className="text-sm font-semibold text-[var(--m-text)]">
+            {area.title}
+          </h2>
+          <p className="mt-0.5 text-xs text-[var(--m-text-secondary)]">
+            {area.question}
+          </p>
+          <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1">
+            {area.signals.map((s) => (
+              <span key={s.key} className="text-xs text-[var(--m-text-tertiary)]">
+                <span
+                  className={
+                    s.count > 0
+                      ? 'font-semibold text-[var(--m-text)]'
+                      : 'font-semibold'
+                  }
+                >
+                  {s.count}
+                </span>{' '}
+                {s.label}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {clean ? (
+          <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-[var(--m-success-bg)] px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-[var(--m-success-text)]">
+            <CheckCircle2 className="h-3.5 w-3.5" />
+            Clear
+          </span>
+        ) : (
+          <span className="shrink-0 rounded-full bg-[var(--m-warning-bg)] px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-[var(--m-warning-text)]">
+            {area.count} to review
+          </span>
+        )}
+
+        <ChevronDown className="h-4 w-4 shrink-0 text-[var(--m-text-tertiary)] transition-transform duration-200 group-open:rotate-180" />
+      </summary>
+
+      <div className="space-y-4 border-t border-[var(--m-border)] p-4">
+        {children}
+      </div>
+    </details>
+  );
+}

--- a/src/components/security/SecurityPostureCard.tsx
+++ b/src/components/security/SecurityPostureCard.tsx
@@ -83,7 +83,7 @@ export function SecurityPostureCard({ posture }: Props) {
                 onMouseLeave={() => setShowTooltip(false)}
                 onFocus={() => setShowTooltip(true)}
                 onBlur={() => setShowTooltip(false)}
-                className="flex items-center text-[var(--m-text-tertiary)] transition-colors hover:text-[var(--m-text-secondary)]"
+                className="-m-1.5 flex items-center p-1.5 text-[var(--m-text-tertiary)] transition-colors hover:text-[var(--m-text-secondary)]"
                 aria-label="How scoring works"
               >
                 <Info className="h-3.5 w-3.5" />

--- a/src/components/shared/CollapsibleSection.tsx
+++ b/src/components/shared/CollapsibleSection.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from 'react';
+import { ChevronDown } from 'lucide-react';
+
+interface Props {
+  title: string;
+  description?: string;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}
+
+/**
+ * A titled section that starts collapsed, for detail a page should offer but
+ * not lead with. Native `<details>`, so keyboard operation and browser
+ * find-in-page work without any state of our own.
+ */
+export function CollapsibleSection({
+  title,
+  description,
+  defaultOpen,
+  children,
+}: Props) {
+  return (
+    <details
+      open={defaultOpen}
+      className="group overflow-hidden rounded-xl border border-[var(--m-border)] bg-[var(--m-bg)]"
+    >
+      <summary className="flex cursor-pointer list-none items-center gap-4 p-4 transition-colors hover:bg-[var(--m-surface-hover)]">
+        <div className="min-w-0 flex-1">
+          <h2 className="text-sm font-semibold text-[var(--m-text)]">{title}</h2>
+          {description && (
+            <p className="mt-0.5 text-xs text-[var(--m-text-secondary)]">
+              {description}
+            </p>
+          )}
+        </div>
+        <ChevronDown className="h-4 w-4 shrink-0 text-[var(--m-text-tertiary)] transition-transform duration-200 group-open:rotate-180" />
+      </summary>
+      <div className="space-y-4 border-t border-[var(--m-border)] p-4">
+        {children}
+      </div>
+    </details>
+  );
+}

--- a/src/components/shared/EmptyState.tsx
+++ b/src/components/shared/EmptyState.tsx
@@ -34,7 +34,7 @@ export function EmptyState({
       {action && (
         <button
           onClick={action.onClick}
-          className="mt-4 rounded-lg bg-[var(--m-primary)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[var(--m-primary-hover)]"
+          className="mt-4 rounded-lg bg-[var(--m-primary-600)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[var(--m-primary-700)]"
         >
           {action.label}
         </button>

--- a/src/components/shared/ErrorBoundary.tsx
+++ b/src/components/shared/ErrorBoundary.tsx
@@ -49,7 +49,7 @@ export class ErrorBoundary extends Component<Props, State> {
             </p>
             <button
               onClick={this.handleRetry}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--m-primary)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[var(--m-primary-hover)]"
+              className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--m-primary-600)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[var(--m-primary-700)]"
             >
               Try Again
             </button>

--- a/src/index.css
+++ b/src/index.css
@@ -151,6 +151,11 @@
   --m-transition-enter: 250ms ease-out;
   --m-transition-exit:  150ms ease-in;
 
+  /* ─── MOTION (entrance/hero animations) ──────────────────── */
+  --m-motion-hero-duration: 400ms;
+  --m-motion-hero-ease: cubic-bezier(0.16, 1, 0.3, 1); /* ease-out, no overshoot */
+  --m-motion-stagger-step: 40ms; /* per-item delay, e.g. health-grid tiles */
+
   /* ─── Z-INDEX SCALE ──────────────────────────────────────── */
   --m-z-base:     0;
   --m-z-raised:   10;
@@ -373,6 +378,15 @@
 
 .animate-skeleton {
   animation: skeleton-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes m-enter-up {
+  from { opacity: 0; transform: translateY(10px); }
+  to   { opacity: 1; transform: none; }
+}
+
+.m-enter-up {
+  animation: m-enter-up var(--m-motion-hero-duration) var(--m-motion-hero-ease) both;
 }
 
 /* ── Print styles (Report page) ─────────────────────────────────────── */

--- a/src/index.css
+++ b/src/index.css
@@ -34,17 +34,20 @@
   --m-neutral-900: #16191D;
   --m-neutral-950: #0D0F12;
 
-  /* ─── PRIMARY PALETTE (Deep Indigo) ─────────────────────── */
-  --m-primary-50:  #EEF2FF;
-  --m-primary-100: #E0E7FF;
-  --m-primary-200: #C7D2FE;
-  --m-primary-300: #A5B4FC;
-  --m-primary-400: #818CF8;
-  --m-primary-500: #6366F1;
-  --m-primary-600: #4F46E5;
-  --m-primary-700: #4338CA;
-  --m-primary-800: #3730A3;
-  --m-primary-900: #312E81;
+  /* ─── PRIMARY PALETTE (Cobalt) ───────────────────────────── */
+  --m-primary-50:  #EFF6FF;
+  --m-primary-100: #DBEAFE;
+  --m-primary-200: #BFDBFE;
+  --m-primary-300: #93C5FD;
+  --m-primary-400: #60A5FA;
+  --m-primary-500: #3B82F6;
+  --m-primary-600: #2563EB;
+  --m-primary-700: #1D4ED8;
+  --m-primary-800: #1E40AF;
+  --m-primary-900: #1E3A8A;
+
+  --m-secondary: #06B6D4;
+  --m-gradient-brand: linear-gradient(90deg, #2563EB, #06B6D4);
 
   /* ─── ACCENT PALETTE (Warm Amber) ───────────────────────── */
   --m-accent-50:  #FFFBEB;

--- a/src/index.css
+++ b/src/index.css
@@ -335,6 +335,15 @@
   font-size: clamp(2.25rem, 5vw, 3.5rem); /* 36px to 56px */
 }
 
+/* Brand gradient on text. Reserved for "moments": wordmark, hero accent,
+   primary CTA. Never on dense surfaces. */
+.m-gradient-text {
+  background: var(--m-gradient-brand);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
 /* ── Accessibility ── */
 
 :focus-visible {

--- a/src/index.css
+++ b/src/index.css
@@ -395,6 +395,10 @@
   *, *::before, *::after {
     animation-duration: 0.01ms !important;
     transition-duration: 0.01ms !important;
+    /* Delays too: a staggered entrance with `both` fill would otherwise hold
+       content at opacity 0 for the length of its delay before snapping in. */
+    animation-delay: 0s !important;
+    transition-delay: 0s !important;
   }
 }
 
@@ -435,6 +439,16 @@
 
 .m-enter-up {
   animation: m-enter-up var(--m-motion-hero-duration) var(--m-motion-hero-ease) both;
+}
+
+@keyframes m-tile-in {
+  from { opacity: 0; transform: scale(0.85); }
+  to   { opacity: 1; transform: none; }
+}
+
+/* Health-grid tiles. The per-tile delay is set inline from the item index. */
+.m-tile-in {
+  animation: m-tile-in 200ms var(--m-motion-hero-ease) both;
 }
 
 /* ── Print styles (Report page) ─────────────────────────────────────── */

--- a/src/index.css
+++ b/src/index.css
@@ -28,6 +28,10 @@
   --m-neutral-300: #DEE2E6;
   --m-neutral-400: #ADB5BD;
   --m-neutral-500: #868E96;
+  /* Inserted step: neutral-500 on white is 3.32:1, under AA for the small
+     helper text --m-text-tertiary drives. This lands at 5.0:1 and still reads
+     lighter than neutral-600 body text. */
+  --m-neutral-550: #67707A;
   --m-neutral-600: #495057;
   --m-neutral-700: #343A40;
   --m-neutral-800: #212529;
@@ -45,6 +49,7 @@
   --m-primary-700: #1D4ED8;
   --m-primary-800: #1E40AF;
   --m-primary-900: #1E3A8A;
+  --m-primary-950: #172554;
 
   --m-secondary: #06B6D4;
   --m-gradient-brand: linear-gradient(90deg, #2563EB, #06B6D4);
@@ -65,7 +70,9 @@
   --m-success:      #15803D;
   --m-success-bg:   #F0FDF4;
   --m-success-text: #14532D;
-  --m-warning:      #EA580C;
+  /* orange-700, not 600: this token is used as TEXT on white in several places
+     ("None", counts), where orange-600 sits at 3.56:1. */
+  --m-warning:      #C2410C;
   --m-warning-bg:   #FFF7ED;
   --m-warning-text: #9A3412;
   --m-error:        #DC2626;
@@ -83,7 +90,7 @@
   --m-border-subtle:  var(--m-neutral-100);
   --m-text:           var(--m-neutral-800);
   --m-text-secondary: var(--m-neutral-600);
-  --m-text-tertiary:  var(--m-neutral-500);
+  --m-text-tertiary:  var(--m-neutral-550);
   --m-primary:        var(--m-primary-600);
   --m-primary-hover:  var(--m-primary-700);
   --m-primary-subtle: var(--m-primary-50);
@@ -95,8 +102,8 @@
   --health-a:    #15803D;  --health-a-bg: #F0FDF4;  /* Emerald — Meridian success */
   --health-b:    #4F46E5;  --health-b-bg: #EEF2FF;  /* Indigo  — Meridian primary */
   --health-c:    #B45309;  --health-c-bg: #FFFBEB;  /* Amber   — Meridian accent  */
-  --health-d:    #EA580C;  --health-d-bg: #FFF7ED;  /* Orange  — Meridian warning */
-  --health-f:    #DC2626;  --health-f-bg: #FEF2F2;  /* Red     — Meridian error   */
+  --health-d:    #C2410C;  --health-d-bg: #FFF7ED;  /* Orange  — Meridian warning */
+  --health-f:    #B91C1C;  --health-f-bg: #FEF2F2;  /* Red-700 — clears AA on its own bg tint */
 
   /* ─── FABRIC-LENS EXTENSIONS: Status ────────────────────── */
   --status-active:       #15803D;  --status-active-bg:   #F0FDF4;
@@ -227,7 +234,9 @@
   --m-text-tertiary:  var(--m-neutral-500);
   --m-primary:        var(--m-primary-400);
   --m-primary-hover:  var(--m-primary-300);
-  --m-primary-subtle: var(--m-primary-900);
+  /* 950, not 900: --m-primary (400) on 900 lands at 4.07:1, under AA for the
+     small uppercase labels that use this pair (SKU badges, role chips). */
+  --m-primary-subtle: var(--m-primary-950);
   --m-secondary:       #22D3EE;  /* cyan-400: high contrast on #0D0F12 */
   --m-gradient-brand:  linear-gradient(90deg, #60A5FA, #22D3EE);
   --m-accent:         var(--m-accent-400);

--- a/src/index.css
+++ b/src/index.css
@@ -317,6 +317,19 @@
   border-radius: var(--m-radius-sm);
 }
 
+/* ── Display Typography ── */
+
+.m-display {
+  font-family: var(--m-font-primary);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  line-height: 1.04;
+}
+
+.m-display-hero {
+  font-size: clamp(2.25rem, 5vw, 3.5rem); /* 36px to 56px */
+}
+
 /* ── Accessibility ── */
 
 :focus-visible {

--- a/src/index.css
+++ b/src/index.css
@@ -344,6 +344,45 @@
   color: transparent;
 }
 
+/* Pill CTAs. `.m-cta` is the gradient primary (one per view, the conversion
+   action); `.m-cta-ghost` is the bordered companion. Sized to clear the 44px
+   touch target at the default font size. */
+.m-cta,
+.m-cta-ghost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  padding: 0.75rem 1.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  transition: opacity 120ms ease, background-color 120ms ease;
+}
+
+.m-cta {
+  background-image: var(--m-gradient-brand);
+  color: #ffffff;
+}
+
+.m-cta:hover {
+  opacity: 0.9;
+}
+
+/* The dark gradient runs light (primary-400 to cyan-400), so the label flips to
+   the dark base to keep AA. White on that gradient sits near 2.4:1. */
+.dark .m-cta {
+  color: var(--m-neutral-950);
+}
+
+.m-cta-ghost {
+  border: 1px solid var(--m-border);
+  color: var(--m-text);
+}
+
+.m-cta-ghost:hover {
+  background-color: var(--m-surface-hover);
+}
+
 /* ── Accessibility ── */
 
 :focus-visible {

--- a/src/index.css
+++ b/src/index.css
@@ -223,6 +223,8 @@
   --m-primary:        var(--m-primary-400);
   --m-primary-hover:  var(--m-primary-300);
   --m-primary-subtle: var(--m-primary-900);
+  --m-secondary:       #22D3EE;  /* cyan-400: high contrast on #0D0F12 */
+  --m-gradient-brand:  linear-gradient(90deg, #60A5FA, #22D3EE);
   --m-accent:         var(--m-accent-400);
   --m-accent-vivid:   var(--m-accent-300);
   --m-accent-subtle:  var(--m-accent-900);

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -279,7 +279,7 @@ export function AboutPage() {
                   { grade: 'A', label: '≥ 90%', color: 'bg-[#15803D] text-white' },
                   { grade: 'B', label: '≥ 80%', color: 'bg-[#4F46E5] text-white' },
                   { grade: 'C', label: '≥ 65%', color: 'bg-[#B45309] text-white' },
-                  { grade: 'D', label: '≥ 50%', color: 'bg-[#EA580C] text-white' },
+                  { grade: 'D', label: '≥ 50%', color: 'bg-[#C2410C] text-white' },
                   { grade: 'F', label: '< 50%', color: 'bg-[#DC2626] text-white' },
                 ].map(({ grade, label, color }) => (
                   <div key={grade} className="flex items-center gap-2">

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -72,7 +72,7 @@ export function AboutPage() {
             <span className="text-sm text-[var(--m-text-secondary)]">About</span>
           </div>
           <Link
-            to="/"
+            to="/dashboard"
             className="flex items-center gap-1.5 rounded-lg bg-[var(--m-primary)] px-3 py-1.5 text-sm font-medium text-white transition-opacity hover:opacity-90"
           >
             Open dashboard

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,5 +1,5 @@
-import { Link } from 'react-router';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
+import { GITHUB_URL, GITHUB_ISSUES_URL } from '@/utils/constants';
 import {
   ShieldCheck,
   LayoutDashboard,
@@ -58,30 +58,10 @@ const toc = [
 
 export function AboutPage() {
   useDocumentTitle('About');
+  // Page chrome (nav, footer, background) comes from MarketingShell.
   return (
-    <div className="min-h-screen bg-[var(--m-bg)] text-[var(--m-text)]">
-      {/* Top bar */}
-      <header className="sticky top-0 z-10 border-b border-[var(--m-border)] bg-[var(--m-bg)]/90 backdrop-blur">
-        <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-6">
-          <div className="flex items-center gap-2.5">
-            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-[var(--m-primary)] text-xs font-bold text-white">
-              F
-            </div>
-            <span className="text-sm font-semibold text-[var(--m-text)]">fabric-lens</span>
-            <span className="text-[var(--m-text-tertiary)]">/</span>
-            <span className="text-sm text-[var(--m-text-secondary)]">About</span>
-          </div>
-          <Link
-            to="/dashboard"
-            className="flex items-center gap-1.5 rounded-lg bg-[var(--m-primary)] px-3 py-1.5 text-sm font-medium text-white transition-opacity hover:opacity-90"
-          >
-            Open dashboard
-          </Link>
-        </div>
-      </header>
-
-      <div className="mx-auto max-w-6xl px-6 py-12">
-        <div className="flex gap-12">
+    <div className="mx-auto max-w-6xl px-6 py-12">
+      <div className="flex gap-12">
           {/* Table of contents (sticky sidebar) */}
           <aside className="hidden w-52 shrink-0 lg:block">
             <div className="sticky top-24">
@@ -373,7 +353,7 @@ export function AboutPage() {
                   {
                     icon: GitFork,
                     label: 'GitHub repository',
-                    href: 'https://github.com/psistla/fabric-lens',
+                    href: GITHUB_URL,
                   },
                   {
                     icon: ExternalLink,
@@ -383,7 +363,7 @@ export function AboutPage() {
                   {
                     icon: ExternalLink,
                     label: 'Report an issue',
-                    href: 'https://github.com/psistla/fabric-lens/issues',
+                    href: GITHUB_ISSUES_URL,
                   },
                 ].map(({ icon: Icon, label, href }) => (
                   <a
@@ -401,7 +381,6 @@ export function AboutPage() {
             </Section>
           </main>
         </div>
-      </div>
     </div>
   );
 }

--- a/src/pages/CapacityPage.tsx
+++ b/src/pages/CapacityPage.tsx
@@ -15,6 +15,8 @@ import { useWorkspaceStore } from '@/store/workspaceStore';
 import { StateBadge } from '@/components/shared/StateBadge';
 import { ExportButton } from '@/components/shared/ExportButton';
 import { exportToCSV } from '@/utils/export';
+import { CollapsibleSection } from '@/components/shared/CollapsibleSection';
+import { HOURS_PER_MONTH } from '@/utils/constants';
 import { SKU_SPECS, SKU_NAMES, SKU_TIER_STYLES, buildSkuSpecsWithRates } from '@/data/skuSpecs';
 import type { SkuSpec } from '@/data/skuSpecs';
 import { fetchSkuRates, AZURE_REGIONS } from '@/api/azurePricing';
@@ -466,15 +468,28 @@ export function CapacityPage() {
     return counts;
   }, [workspaces]);
 
+  // Headline cost: active capacities only, at the SKU list rate for a full
+  // month. Paused capacities bill nothing, so they are left out.
+  const { activeCount, monthlyRunRate } = useMemo(() => {
+    const active = capacities.filter((c) => c.state === 'Active');
+    const hourly = active.reduce(
+      (sum, c) => sum + (SKU_SPECS[c.sku]?.rate ?? 0),
+      0,
+    );
+    return { activeCount: active.length, monthlyRunRate: hourly * HOURS_PER_MONTH };
+  }, [capacities]);
+
   return (
     <div className="space-y-6 p-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
           <h1 className="text-2xl font-semibold tracking-[-0.02em] text-[var(--m-text)]">
             Capacities
           </h1>
           <p className="mt-1 text-sm text-[var(--m-text-secondary)]">
-            Monitor Fabric capacity usage and specifications.
+            {capacities.length > 0
+              ? `${activeCount} active, ${capacities.length - activeCount} paused, about $${monthlyRunRate.toLocaleString('en-US', { maximumFractionDigits: 0 })}/mo at list price if run 24/7.`
+              : 'Monitor Fabric capacity usage and specifications.'}
           </p>
         </div>
         {capacities.length > 0 && (
@@ -606,8 +621,14 @@ export function CapacityPage() {
         )}
       </div>
 
-      {/* Cost Calculator */}
-      <CostCalculator />
+      {/* Cost modelling is a what-if tool, not a status readout, so it opens on
+          request rather than competing with the capacity list. */}
+      <CollapsibleSection
+        title="Cost calculator"
+        description="Model a SKU against hours, days, and autoscale."
+      >
+        <CostCalculator />
+      </CollapsibleSection>
     </div>
   );
 }

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -26,6 +26,7 @@ import { aggregateGovernanceIssues } from '@/utils/governanceIssues';
 import { calculateWorkspaceHealth } from '@/utils/healthScore';
 import type { HealthScore } from '@/utils/healthScore';
 import { ExportButton } from '@/components/shared/ExportButton';
+import { CollapsibleSection } from '@/components/shared/CollapsibleSection';
 import { HealthGrid } from '@/components/dashboard/HealthGrid';
 import { SecurityQuickView } from '@/components/dashboard/SecurityQuickView';
 import { ScoreRing } from '@/components/dashboard/ScoreRing';
@@ -281,7 +282,7 @@ export function DashboardPage() {
       )}
 
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
           <h1 className="text-2xl font-semibold tracking-[-0.02em] text-[var(--m-text)]">
             Governance Posture Assessment
@@ -358,9 +359,7 @@ export function DashboardPage() {
         />
       </div>
 
-      <SecurityQuickView />
-
-      {/* Section 2: Health Grid */}
+      {/* Section 2: Health Grid — the signature view, directly under the score */}
       {workspaces.length > 0 && (
         <HealthGrid
           workspaces={healthGridData}
@@ -368,14 +367,21 @@ export function DashboardPage() {
         />
       )}
 
-      {/* Section 3: Governance Issues */}
+      {/* Section 3: what to do about it */}
       <GovernanceIssuesPanel issues={aggregatedIssues} workspaces={workspaces} />
 
-      {/* Section 4: Health Grade Distribution */}
-      <div className="rounded-xl border border-[var(--m-border)] bg-[var(--m-bg)] p-4">
-        <h2 className="mb-3 text-[11px] font-semibold uppercase tracking-[0.04em] text-[var(--m-text-secondary)]">
+      <SecurityQuickView />
+
+      {/* Section 4: distributions. Useful context, but they answer "how is the
+          tenant shaped", not "what needs attention", so they sit behind a fold. */}
+      <CollapsibleSection
+        title="Distributions"
+        description="Health grades and item types across the tenant."
+      >
+      <div>
+        <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-[0.04em] text-[var(--m-text-secondary)]">
           Health Grade Distribution
-        </h2>
+        </h3>
         {gradeDist.length > 0 ? (
           <ResponsiveContainer width="100%" height={180}>
             <BarChart
@@ -417,10 +423,10 @@ export function DashboardPage() {
 
       {/* Section 5: Item Distribution */}
       {itemDist.length > 0 && (
-        <div className="rounded-xl border border-[var(--m-border)] bg-[var(--m-bg)] p-4">
-          <h2 className="mb-3 text-[11px] font-semibold uppercase tracking-[0.04em] text-[var(--m-text-secondary)]">
+        <div>
+          <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-[0.04em] text-[var(--m-text-secondary)]">
             Item Distribution
-          </h2>
+          </h3>
           <div className="flex flex-wrap gap-2">
             {itemDist.map((entry) => (
               <div
@@ -445,6 +451,7 @@ export function DashboardPage() {
           </div>
         </div>
       )}
+      </CollapsibleSection>
     </div>
   );
 }

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -300,7 +300,7 @@ export function DashboardPage() {
           {workspaces.length > 0 && (
             <button
               onClick={() => navigate('/report')}
-              className="flex items-center gap-1.5 text-sm px-3 py-1.5 rounded-lg bg-[var(--m-primary)] text-white hover:opacity-90 transition-opacity"
+              className="flex items-center gap-1.5 text-sm px-3 py-1.5 rounded-lg bg-[var(--m-primary-600)] text-white hover:opacity-90 transition-opacity"
             >
               <FileText className="h-3.5 w-3.5" />
               Generate Report

--- a/src/pages/ReportPage.tsx
+++ b/src/pages/ReportPage.tsx
@@ -131,7 +131,7 @@ export function ReportPage() {
         </div>
         <div className="flex items-center gap-2">
           <Link
-            to="/"
+            to="/dashboard"
             className="text-sm px-3 py-1.5 rounded-md border border-[var(--m-border)] text-[var(--m-text-secondary)] hover:text-[var(--m-text)]"
           >
             ← Back to Dashboard

--- a/src/pages/ReportPage.tsx
+++ b/src/pages/ReportPage.tsx
@@ -138,7 +138,7 @@ export function ReportPage() {
           </Link>
           <button
             onClick={() => window.print()}
-            className="flex items-center gap-1.5 text-sm px-3 py-1.5 rounded-md bg-[var(--m-primary)] text-white hover:opacity-90"
+            className="flex items-center gap-1.5 text-sm px-3 py-1.5 rounded-md bg-[var(--m-primary-600)] text-white hover:opacity-90"
           >
             <Printer className="h-3.5 w-3.5" />
             Print / Save PDF

--- a/src/pages/SecurityPage.tsx
+++ b/src/pages/SecurityPage.tsx
@@ -131,7 +131,7 @@ function AdminConsentCard({ onGrant, granting, error }: ConsentCardProps) {
       <button
         onClick={onGrant}
         disabled={granting}
-        className="inline-flex items-center gap-2 rounded-lg bg-[var(--m-primary)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[var(--m-primary-hover)] disabled:opacity-50"
+        className="inline-flex items-center gap-2 rounded-lg bg-[var(--m-primary-600)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[var(--m-primary-700)] disabled:opacity-50"
       >
         {granting ? 'Requesting access...' : 'Grant Admin Access'}
       </button>
@@ -612,7 +612,7 @@ export function SecurityPage() {
           </p>
           <button
             onClick={() => void checkAdminAccess()}
-            className="inline-flex items-center gap-2 rounded-lg bg-[var(--m-primary)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[var(--m-primary-hover)]"
+            className="inline-flex items-center gap-2 rounded-lg bg-[var(--m-primary-600)] px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-[var(--m-primary-700)]"
           >
             Retry
           </button>
@@ -684,7 +684,7 @@ export function SecurityPage() {
           <button
             onClick={() => void handleScanAll()}
             disabled={loading || wsLoading}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--m-primary)] px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-[var(--m-primary-hover)] disabled:opacity-50"
+            className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--m-primary-600)] px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-[var(--m-primary-700)] disabled:opacity-50"
           >
             <ScanSearch className="h-3.5 w-3.5" />
             {hasScanned ? 'Re-scan All' : 'Scan All'}
@@ -763,7 +763,7 @@ export function SecurityPage() {
                 <button
                   onClick={() => void handleScanAll()}
                   disabled={loading || wsLoading}
-                  className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--m-primary)] px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-[var(--m-primary-hover)] disabled:opacity-50"
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--m-primary-600)] px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-[var(--m-primary-700)] disabled:opacity-50"
                 >
                   <ScanSearch className="h-3.5 w-3.5" />
                   Scan All
@@ -887,7 +887,7 @@ export function SecurityPage() {
                           className={[
                             'px-3 py-1.5 text-[11px] font-semibold transition-colors',
                             (v === 'mine') === myOnly
-                              ? 'bg-[var(--m-primary)] text-white'
+                              ? 'bg-[var(--m-primary-600)] text-white'
                               : 'bg-[var(--m-surface)] text-[var(--m-text-secondary)] hover:bg-[var(--m-surface-raised)]',
                           ].join(' ')}
                         >
@@ -901,7 +901,7 @@ export function SecurityPage() {
                       onClick={() => setPivotView('users')}
                       className={`rounded-md px-2.5 py-1 transition-colors ${
                         pivotView === 'users'
-                          ? 'bg-[var(--m-primary)] text-white'
+                          ? 'bg-[var(--m-primary-600)] text-white'
                           : 'text-[var(--m-text-secondary)] hover:text-[var(--m-text)]'
                       }`}
                     >
@@ -911,7 +911,7 @@ export function SecurityPage() {
                       onClick={() => setPivotView('workspaces')}
                       className={`rounded-md px-2.5 py-1 transition-colors ${
                         pivotView === 'workspaces'
-                          ? 'bg-[var(--m-primary)] text-white'
+                          ? 'bg-[var(--m-primary-600)] text-white'
                           : 'text-[var(--m-text-secondary)] hover:text-[var(--m-text)]'
                       }`}
                     >
@@ -1159,7 +1159,7 @@ export function SecurityPage() {
                           onClick={() => setCurrentPage(p)}
                           className={`h-7 w-7 rounded-lg text-xs font-semibold transition-colors ${
                             p === safePage
-                              ? 'bg-[var(--m-primary)] text-white'
+                              ? 'bg-[var(--m-primary-600)] text-white'
                               : 'text-[var(--m-text-secondary)] hover:bg-[var(--m-surface-hover)]'
                           }`}
                         >

--- a/src/pages/SecurityPage.tsx
+++ b/src/pages/SecurityPage.tsx
@@ -11,6 +11,7 @@ import {
   ArrowUpDown,
   ArrowUp,
   ArrowDown,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
   UsersRound,
@@ -40,7 +41,13 @@ import { SpnGovernancePanel } from '@/components/security/SpnGovernancePanel';
 import { SpofWorkspacesPanel } from '@/components/security/SpofWorkspacesPanel';
 import { AccessConcentrationChart } from '@/components/security/AccessConcentrationChart';
 import { WorkspacePivotTable } from '@/components/security/WorkspacePivotTable';
+import { SecurityAreaSection } from '@/components/security/SecurityAreaSection';
 import { deriveSecurityFindings, computeSecurityPosture } from '@/utils/securityFindings';
+import {
+  groupSecurityAreas,
+  type SecurityArea,
+  type SecurityAreaId,
+} from '@/utils/securityAreas';
 import { deriveRiskySettings } from '@/utils/tenantSettingRisks';
 import { exportToCSV } from '@/utils/export';
 import { isEffectiveDemoMode } from '@/auth/AuthProvider';
@@ -402,6 +409,35 @@ export function SecurityPage() {
       ),
     [userSummaries],
   );
+
+  // Drill-in areas for the page IA. The SPOF and elevated-SPN counts come off
+  // the findings that already derive them, rather than re-deriving here.
+  const areas = useMemo(() => {
+    const affected = (id: string) =>
+      securityFindings.find((f) => f.id === id)?.affectedItems.length ?? 0;
+
+    const grouped = groupSecurityAreas({
+      findings: securityFindings,
+      overPermissionedCount: overPermissioned.length,
+      spofCount: affected('spof-single-admin'),
+      spnElevatedCount: affected('spn-admin-role'),
+      riskySettingsCount: riskySettings.length,
+      widelySharedCount: artifacts.length,
+      unassignedDomainCount: unassignedCount,
+      ghostCount: ghostWorkspaces.length,
+    });
+    return Object.fromEntries(grouped.map((a) => [a.id, a])) as Record<
+      SecurityAreaId,
+      SecurityArea
+    >;
+  }, [
+    securityFindings,
+    overPermissioned,
+    riskySettings,
+    artifacts,
+    unassignedCount,
+    ghostWorkspaces,
+  ]);
 
   // --- Expanded groups state ---
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
@@ -786,41 +822,18 @@ export function SecurityPage() {
           {/* Security Findings Panel */}
           <SecurityFindingsPanel findings={securityFindings} />
 
-          {/* Tenant Settings Risk Panel */}
-          <TenantSettingsRiskPanel
-            settings={riskySettings}
-            loading={settingsLoading}
-            error={settingsError}
-            onRetry={fetchTenantSettings}
-          />
-
-          {/* Widely Shared Panel */}
-          <WidelySharedPanel
-            artifacts={artifacts}
-            loading={widelySharedLoading}
-            error={widelySharedError}
-            onRetry={fetchWidelySharedArtifacts}
-          />
-
-          {/* Domain Governance Panel */}
-          <DomainGovernancePanel
-            domainStats={domainStats}
-            unassignedCount={unassignedCount}
-            totalWorkspaces={domainTotalWorkspaces}
-            hasCrossDomainSharing={artifacts.length > 0}
-          />
-
-          {/* SPOF Workspaces Panel */}
-          <SpofWorkspacesPanel workspaceUsers={workspaceUsers} workspaces={filteredWorkspaces} />
-
-          {/* SPN Governance Panel */}
-          <SpnGovernancePanel userSummaries={userSummaries} />
-
-          {/* Access Concentration Charts */}
-          <AccessConcentrationChart
-            workspaceUsers={workspaceUsers}
-            userSummaries={userSummaries}
-          />
+          {/* Drill-in areas. Every panel that used to sit on the page still
+              renders, grouped under the area it belongs to. */}
+          <SecurityAreaSection area={areas.access}>
+            <SpofWorkspacesPanel workspaceUsers={workspaceUsers} workspaces={filteredWorkspaces} />
+            <SpnGovernancePanel userSummaries={userSummaries} />
+            <AccessConcentrationChart
+              workspaceUsers={workspaceUsers}
+              userSummaries={userSummaries}
+            />
+            {effectiveAccessSummary && (
+              <EffectiveAccessCard summary={effectiveAccessSummary} />
+            )}
 
           {/* Over-permissioned alert */}
           {overPermissioned.length > 0 && (
@@ -855,23 +868,55 @@ export function SecurityPage() {
               </ul>
             </div>
           )}
+          </SecurityAreaSection>
 
-          {/* Effective Access Card */}
-          {effectiveAccessSummary && (
-            <EffectiveAccessCard summary={effectiveAccessSummary} />
-          )}
+          <SecurityAreaSection area={areas.sharing}>
+            <WidelySharedPanel
+              artifacts={artifacts}
+              loading={widelySharedLoading}
+              error={widelySharedError}
+              onRetry={fetchWidelySharedArtifacts}
+            />
+            <DomainGovernancePanel
+              domainStats={domainStats}
+              unassignedCount={unassignedCount}
+              totalWorkspaces={domainTotalWorkspaces}
+              hasCrossDomainSharing={artifacts.length > 0}
+            />
+          </SecurityAreaSection>
 
-          {/* Ghost Workspaces Panel */}
-          <GhostWorkspacesPanel
-            ghostWorkspaces={ghostWorkspaces}
-            workspaces={workspaces}
-            loading={ghostLoading}
-            error={ghostError}
-            onRetry={() => void fetchActivityEvents(workspaces)}
-          />
+          <SecurityAreaSection area={areas.settings}>
+            <TenantSettingsRiskPanel
+              settings={riskySettings}
+              loading={settingsLoading}
+              error={settingsError}
+              onRetry={fetchTenantSettings}
+            />
+          </SecurityAreaSection>
 
-          {/* User / Workspace pivot table */}
-          <div className="rounded-xl border border-[var(--m-border)] bg-[var(--m-bg)]">
+          <SecurityAreaSection area={areas.lifecycle}>
+            <GhostWorkspacesPanel
+              ghostWorkspaces={ghostWorkspaces}
+              workspaces={workspaces}
+              loading={ghostLoading}
+              error={ghostError}
+              onRetry={() => void fetchActivityEvents(workspaces)}
+            />
+          </SecurityAreaSection>
+
+          {/* Directory: the raw user/workspace pivot, one level down from the
+              summary because it answers "show me everything", not "what is wrong". */}
+          <details className="group overflow-hidden rounded-xl border border-[var(--m-border)] bg-[var(--m-bg)]">
+            <summary className="flex cursor-pointer list-none items-center gap-4 p-4 transition-colors hover:bg-[var(--m-surface-hover)]">
+              <div className="min-w-0 flex-1">
+                <h2 className="text-sm font-semibold text-[var(--m-text)]">Directory</h2>
+                <p className="mt-0.5 text-xs text-[var(--m-text-secondary)]">
+                  Every principal and workspace, searchable and exportable.
+                </p>
+              </div>
+              <ChevronDown className="h-4 w-4 shrink-0 text-[var(--m-text-tertiary)] transition-transform duration-200 group-open:rotate-180" />
+            </summary>
+          <div className="border-t border-[var(--m-border)]">
               {/* Header with toggle */}
               <div className="flex items-center justify-between border-b border-[var(--m-border)] px-4 py-3">
                 <h2 className="text-sm font-medium text-[var(--m-text)]">
@@ -1180,6 +1225,7 @@ export function SecurityPage() {
               </>
               )}
             </div>
+          </details>
         </>
       )}
     </div>

--- a/src/pages/SecurityPage.tsx
+++ b/src/pages/SecurityPage.tsx
@@ -11,7 +11,6 @@ import {
   ArrowUpDown,
   ArrowUp,
   ArrowDown,
-  ChevronDown,
   ChevronLeft,
   ChevronRight,
   UsersRound,
@@ -42,6 +41,7 @@ import { SpofWorkspacesPanel } from '@/components/security/SpofWorkspacesPanel';
 import { AccessConcentrationChart } from '@/components/security/AccessConcentrationChart';
 import { WorkspacePivotTable } from '@/components/security/WorkspacePivotTable';
 import { SecurityAreaSection } from '@/components/security/SecurityAreaSection';
+import { CollapsibleSection } from '@/components/shared/CollapsibleSection';
 import { deriveSecurityFindings, computeSecurityPosture } from '@/utils/securityFindings';
 import {
   groupSecurityAreas,
@@ -906,17 +906,11 @@ export function SecurityPage() {
 
           {/* Directory: the raw user/workspace pivot, one level down from the
               summary because it answers "show me everything", not "what is wrong". */}
-          <details className="group overflow-hidden rounded-xl border border-[var(--m-border)] bg-[var(--m-bg)]">
-            <summary className="flex cursor-pointer list-none items-center gap-4 p-4 transition-colors hover:bg-[var(--m-surface-hover)]">
-              <div className="min-w-0 flex-1">
-                <h2 className="text-sm font-semibold text-[var(--m-text)]">Directory</h2>
-                <p className="mt-0.5 text-xs text-[var(--m-text-secondary)]">
-                  Every principal and workspace, searchable and exportable.
-                </p>
-              </div>
-              <ChevronDown className="h-4 w-4 shrink-0 text-[var(--m-text-tertiary)] transition-transform duration-200 group-open:rotate-180" />
-            </summary>
-          <div className="border-t border-[var(--m-border)]">
+          <CollapsibleSection
+            title="Directory"
+            description="Every principal and workspace, searchable and exportable."
+          >
+          <div>
               {/* Header with toggle */}
               <div className="flex items-center justify-between border-b border-[var(--m-border)] px-4 py-3">
                 <h2 className="text-sm font-medium text-[var(--m-text)]">
@@ -1225,7 +1219,7 @@ export function SecurityPage() {
               </>
               )}
             </div>
-          </details>
+          </CollapsibleSection>
         </>
       )}
     </div>

--- a/src/pages/SecurityPage.tsx
+++ b/src/pages/SecurityPage.tsx
@@ -1125,7 +1125,7 @@ export function SecurityPage() {
                                         `/workspaces/${a.workspaceId}`,
                                       );
                                     }}
-                                    className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide transition-colors hover:ring-1 ${
+                                    className={`inline-flex items-center gap-1 rounded-full px-2 py-1 text-[11px] font-semibold uppercase tracking-wide transition-colors hover:ring-1 ${
                                       a.role === 'Admin'
                                         ? 'bg-[var(--m-error-bg)] text-[var(--m-error-text)] hover:ring-[var(--m-error)]/40'
                                         : a.role === 'Member'

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -225,7 +225,7 @@ function PermissionsSection() {
                 <button
                   onClick={row.onGrant}
                   disabled={row.granting}
-                  className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--m-primary)] px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-[var(--m-primary-hover)] disabled:opacity-50"
+                  className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--m-primary-600)] px-3 py-1.5 text-xs font-semibold text-white transition-colors hover:bg-[var(--m-primary-700)] disabled:opacity-50"
                 >
                   {row.granting ? 'Granting...' : 'Grant Access'}
                 </button>
@@ -372,7 +372,7 @@ function AboutSection() {
       </div>
       <div className="space-y-3 px-5 py-4">
         <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-[var(--m-primary)] text-lg font-bold text-white">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-[var(--m-primary-600)] text-lg font-bold text-white">
             F
           </div>
           <div>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -21,6 +21,7 @@ import {
   HEALTH_SCORE_MAX,
   APP_VERSION,
   GRAPH_SCOPES,
+  GITHUB_URL,
 } from '@/utils/constants';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 
@@ -422,7 +423,7 @@ function AboutSection() {
             About &amp; Docs
           </a>
           <a
-            href="https://github.com/psistla/fabric-lens"
+            href={GITHUB_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-1 text-sm text-[var(--m-primary)]"

--- a/src/pages/WorkspaceDetailPage.tsx
+++ b/src/pages/WorkspaceDetailPage.tsx
@@ -193,6 +193,10 @@ export function WorkspaceDetailPage() {
         </div>
       </div>
 
+      {/* Health leads: the score and the checks that failed are the reason to
+          open a workspace, so they sit above the inventory counts. */}
+      {healthScore && <HealthDetail score={healthScore} />}
+
       {/* Stat cards */}
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
         <StatCard
@@ -221,9 +225,6 @@ export function WorkspaceDetailPage() {
           }
         />
       </div>
-
-      {/* Health Score */}
-      {healthScore && <HealthDetail score={healthScore} />}
 
       {/* OneLake Endpoints */}
       {workspace.oneLakeEndpoints && (

--- a/src/pages/WorkspacesPage.tsx
+++ b/src/pages/WorkspacesPage.tsx
@@ -8,6 +8,8 @@ import { DataTable, type Column } from '@/components/shared/DataTable';
 import { SearchBar } from '@/components/shared/SearchBar';
 import { StateBadge } from '@/components/shared/StateBadge';
 import { ExportButton } from '@/components/shared/ExportButton';
+import { HealthBadge } from '@/components/workspace/HealthBadge';
+import { calculateWorkspaceHealth, type HealthScore } from '@/utils/healthScore';
 import { exportToCSV } from '@/utils/export';
 import { getCurrentUserEmail } from '@/auth/currentUser';
 import { getMyWorkspaceIds } from '@/utils/myWorkspaces';
@@ -18,7 +20,14 @@ import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 export function WorkspacesPage() {
   useDocumentTitle('Workspaces');
   const navigate = useNavigate();
-  const { workspaces, loading, error, fetchWorkspaces } = useWorkspaceStore();
+  const {
+    workspaces,
+    allItemsByWorkspace,
+    loading,
+    error,
+    fetchWorkspaces,
+    fetchAllItems,
+  } = useWorkspaceStore();
   const { fetchCapacities, getCapacityById } = useCapacityStore();
   const { workspaceUsers, populateDemoUsers } = useSecurityStore();
   const [search, setSearch] = useState('');
@@ -31,12 +40,32 @@ export function WorkspacesPage() {
   useEffect(() => {
     void fetchWorkspaces();
     void fetchCapacities();
+    void fetchAllItems();
     populateDemoUsers();
-  }, [fetchWorkspaces, fetchCapacities, populateDemoUsers]);
+  }, [fetchWorkspaces, fetchCapacities, fetchAllItems, populateDemoUsers]);
+
+  // Health per workspace, from the same scorer the dashboard and detail pages use.
+  const healthMap = useMemo(
+    () =>
+      new Map<string, HealthScore>(
+        workspaces.map((w) => [
+          w.id,
+          calculateWorkspaceHealth(w, allItemsByWorkspace[w.id] ?? []),
+        ]),
+      ),
+    [workspaces, allItemsByWorkspace],
+  );
 
   const myWorkspaceIds = useMemo(
     () => (myOnly && userEmail ? getMyWorkspaceIds(userEmail, workspaceUsers) : null),
     [myOnly, userEmail, workspaceUsers],
+  );
+
+  const atRiskCount = useMemo(
+    () =>
+      [...healthMap.values()].filter((h) => h.grade === 'D' || h.grade === 'F')
+        .length,
+    [healthMap],
   );
 
   const filtered = useMemo(() => {
@@ -126,8 +155,22 @@ export function WorkspacesPage() {
         sortable: true,
         render: (_val, row) => <StateBadge state={row.state} />,
       },
+      {
+        // Health is derived, not a Workspace field, so it borrows `id` as its
+        // column key and opts out of sorting rather than widening Column<T>.
+        key: 'id',
+        header: 'Health',
+        sortable: false,
+        render: (_val, row) => {
+          const health = healthMap.get(row.id);
+          if (!health) return null;
+          return (
+            <HealthBadge grade={health.grade} percentage={health.percentage} />
+          );
+        },
+      },
     ],
-    [getCapacityById],
+    [getCapacityById, healthMap],
   );
 
   return (
@@ -138,7 +181,24 @@ export function WorkspacesPage() {
             Workspaces
           </h1>
           <p className="mt-1 text-sm text-[var(--m-text-secondary)]">
-            Browse and manage tenant workspaces.
+            {workspaces.length > 0 ? (
+              <>
+                {workspaces.length} workspace{workspaces.length !== 1 ? 's' : ''}
+                {atRiskCount > 0 ? (
+                  <>
+                    {', '}
+                    <span className="font-semibold text-[var(--m-error)]">
+                      {atRiskCount} at risk
+                    </span>
+                    {' (grade D or F)'}
+                  </>
+                ) : (
+                  ', all grade C or better'
+                )}
+              </>
+            ) : (
+              'Browse and manage tenant workspaces.'
+            )}
           </p>
         </div>
         {workspaces.length > 0 && (

--- a/src/pages/WorkspacesPage.tsx
+++ b/src/pages/WorkspacesPage.tsx
@@ -182,7 +182,7 @@ export function WorkspacesPage() {
                   className={[
                     'px-3 py-1.5 text-xs font-semibold transition-colors',
                     (v === 'mine') === myOnly
-                      ? 'bg-[var(--m-primary)] text-white'
+                      ? 'bg-[var(--m-primary-600)] text-white'
                       : 'bg-[var(--m-surface)] text-[var(--m-text-secondary)] hover:bg-[var(--m-surface-raised)]',
                   ].join(' ')}
                 >

--- a/src/utils/__tests__/securityAreas.test.ts
+++ b/src/utils/__tests__/securityAreas.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { groupSecurityAreas } from '../securityAreas';
+import type { SecurityFinding } from '../securityFindings';
+
+function finding(id: string): SecurityFinding {
+  return {
+    id,
+    severity: 'warning',
+    title: id,
+    detail: id,
+    affectedItems: [],
+  };
+}
+
+const EMPTY = {
+  findings: [],
+  overPermissionedCount: 0,
+  spofCount: 0,
+  spnElevatedCount: 0,
+  riskySettingsCount: 0,
+  widelySharedCount: 0,
+  unassignedDomainCount: 0,
+  ghostCount: 0,
+};
+
+describe('groupSecurityAreas', () => {
+  it('returns the four areas in a stable order even when everything is clean', () => {
+    const areas = groupSecurityAreas(EMPTY);
+    expect(areas.map((a) => a.id)).toEqual([
+      'access',
+      'sharing',
+      'settings',
+      'lifecycle',
+    ]);
+    expect(areas.every((a) => a.count === 0)).toBe(true);
+  });
+
+  it('routes each signal count to its own area', () => {
+    const areas = groupSecurityAreas({
+      ...EMPTY,
+      overPermissionedCount: 2,
+      spofCount: 3,
+      spnElevatedCount: 1,
+      widelySharedCount: 4,
+      unassignedDomainCount: 5,
+      riskySettingsCount: 6,
+      ghostCount: 7,
+    });
+    const byId = Object.fromEntries(areas.map((a) => [a.id, a]));
+
+    expect(byId.access.count).toBe(6); // 2 + 3 + 1
+    expect(byId.sharing.count).toBe(9); // 4 + 5
+    expect(byId.settings.count).toBe(6);
+    expect(byId.lifecycle.count).toBe(7);
+  });
+
+  it('lists member signals with their own counts', () => {
+    const areas = groupSecurityAreas({ ...EMPTY, spofCount: 3 });
+    const access = areas.find((a) => a.id === 'access');
+    expect(access?.signals).toContainEqual(
+      expect.objectContaining({ key: 'spof', count: 3 }),
+    );
+  });
+
+  it('routes findings to the area their rule belongs to', () => {
+    // Every rule `deriveSecurityFindings` ships today is an access-control rule,
+    // so they all land in Access and the other areas stay empty.
+    const areas = groupSecurityAreas({
+      ...EMPTY,
+      findings: [finding('spof-single-admin'), finding('over-permissioned-users')],
+    });
+    const byId = Object.fromEntries(areas.map((a) => [a.id, a]));
+
+    expect(byId.access.findingIds).toEqual([
+      'spof-single-admin',
+      'over-permissioned-users',
+    ]);
+    expect(byId.sharing.findingIds).toEqual([]);
+    expect(byId.settings.findingIds).toEqual([]);
+    expect(byId.lifecycle.findingIds).toEqual([]);
+  });
+
+  it('sends an unrecognized finding to access rather than dropping it', () => {
+    const areas = groupSecurityAreas({
+      ...EMPTY,
+      findings: [finding('some-future-rule')],
+    });
+    const access = areas.find((a) => a.id === 'access');
+    expect(access?.findingIds).toEqual(['some-future-rule']);
+  });
+
+  it('keeps findings out of the headline count, which measures signals', () => {
+    const areas = groupSecurityAreas({
+      ...EMPTY,
+      findings: [finding('spof-single-admin')],
+    });
+    const access = areas.find((a) => a.id === 'access');
+    expect(access?.count).toBe(0);
+  });
+});

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -235,6 +235,9 @@ export const GROUP_EXPAND_INITIAL_COUNT = 10;
 /** Base rate per Capacity Unit per hour (USD). All SKU rates derive from this. */
 export const CU_RATE_PER_HOUR = 0.18;
 
+/** Hours in an average month (365 days / 12), for 24/7 run-rate estimates. */
+export const HOURS_PER_MONTH = 730;
+
 
 // -- Principal types --
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -209,7 +209,7 @@ export const HEALTH_GRADE_COLORS = {
   A: '#15803D',
   B: '#4F46E5',
   C: '#B45309',
-  D: '#EA580C',
+  D: '#C2410C',
   F: '#DC2626',
 } as const;
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -322,6 +322,12 @@ export const HEALTH_GRID_MAX_TILES = 100;
 /** Scale factor applied to a tile on hover. */
 export const HEALTH_GRID_HOVER_SCALE = 1.15;
 
+/** Per-tile entrance delay (ms), mirroring `--m-motion-stagger-step` in CSS. */
+export const HEALTH_GRID_STAGGER_STEP_MS = 20;
+
+/** Ceiling on the stagger so a 100-tile grid still finishes settling quickly. */
+export const HEALTH_GRID_STAGGER_MAX_MS = 400;
+
 // -- App metadata --
 
 /** Application version (mirrors package.json). */

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -77,17 +77,17 @@ export const TOAST_DISMISS_MS = 5000;
 
 // -- Charts --
 
-/** Shared chart color palette (Meridian-aligned sequence). */
+/** Shared chart color palette (Meridian-aligned sequence, cobalt/cyan brand-led). */
 export const CHART_COLORS = [
-  '#4F46E5', '#B45309', '#818CF8', '#FBBF24', '#868E96',
-  '#6366F1', '#D97706', '#15803D', '#0891B2', '#7C3AED',
-  '#DB2777', '#EA580C',
+  '#2563EB', '#06B6D4', '#60A5FA', '#B45309', '#15803D',
+  '#7C3AED', '#DB2777', '#EA580C', '#0891B2', '#FBBF24',
+  '#868E96', '#22D3EE',
 ] as const;
 
 /** Color map for workspace roles (used in Security page charts and badges). */
 export const ROLE_COLORS: Record<string, string> = {
   Admin: '#DC2626',
-  Member: '#4F46E5',
+  Member: '#2563EB',
   Contributor: '#15803D',
   Viewer: '#495057',
 };
@@ -238,7 +238,12 @@ export const CU_RATE_PER_HOUR = 0.18;
 
 // -- Principal types --
 
-/** Color map for principal types (used in Security page badges and charts). */
+/**
+ * Color map for principal types (used in Security page badges and charts).
+ * Reviewed for the cobalt/cyan rebrand: Group's indigo is kept as-is, it
+ * reads distinctly from both the new cobalt primary and the violet
+ * ServicePrincipal entries. Revisit only if an in-context pass says otherwise.
+ */
 export const PRINCIPAL_TYPE_COLORS: Record<string, string> = {
   User: '#495057',
   Group: '#4F46E5',

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -365,3 +365,11 @@ export const BENCHMARK_HEALTH_SCORE = 78;
 
 /** Synthetic median security posture score. Label as "typical" — never "industry average". */
 export const BENCHMARK_SECURITY_SCORE = 72;
+
+// -- External links --
+
+/** Public repository. Single source of truth for every GitHub link in the UI. */
+export const GITHUB_URL = 'https://github.com/psistla/fabric-lens';
+
+/** Issue tracker, used by the About page support links. */
+export const GITHUB_ISSUES_URL = `${GITHUB_URL}/issues`;

--- a/src/utils/securityAreas.ts
+++ b/src/utils/securityAreas.ts
@@ -1,0 +1,124 @@
+import type { SecurityFinding } from './securityFindings';
+
+export type SecurityAreaId = 'access' | 'sharing' | 'settings' | 'lifecycle';
+
+export interface SecurityAreaSignal {
+  /** Stable key, used for React keys and for routing a drill-in to its panel. */
+  key: string;
+  label: string;
+  count: number;
+}
+
+export interface SecurityArea {
+  id: SecurityAreaId;
+  title: string;
+  /** What this area answers, shown under the title on the summary tile. */
+  question: string;
+  /** Headline number: the sum of the member signal counts. */
+  count: number;
+  signals: SecurityAreaSignal[];
+  /** Findings whose rule belongs to this area, for the drill-in view. */
+  findingIds: string[];
+}
+
+export interface SecurityAreaInput {
+  findings: SecurityFinding[];
+  overPermissionedCount: number;
+  spofCount: number;
+  spnElevatedCount: number;
+  riskySettingsCount: number;
+  widelySharedCount: number;
+  unassignedDomainCount: number;
+  ghostCount: number;
+}
+
+/**
+ * Which area each finding rule belongs to. Finding IDs come from
+ * `deriveSecurityFindings`; anything unmapped falls through to Access, which is
+ * where the access-control rules live and where a new rule most likely belongs.
+ */
+const FINDING_AREA: Record<string, SecurityAreaId> = {
+  'spof-single-admin': 'access',
+  'no-admin-workspace': 'access',
+  'spn-admin-role': 'access',
+  'over-permissioned-users': 'access',
+  'unresolved-admin-groups': 'access',
+  'over-administered-workspaces': 'access',
+  'unresolved-groups': 'access',
+};
+
+/**
+ * Group the twelve derived security signals into the four areas the Security
+ * page drills into.
+ *
+ * The headline `count` deliberately sums only the signal counts, not the
+ * findings: a finding is a rule firing ABOUT those same signals, so counting
+ * both would inflate every area by double-reporting the same problem.
+ */
+export function groupSecurityAreas(input: SecurityAreaInput): SecurityArea[] {
+  const areas: Omit<SecurityArea, 'count' | 'findingIds'>[] = [
+    {
+      id: 'access',
+      title: 'Access',
+      question: 'Who can reach what, and is anyone over-privileged?',
+      signals: [
+        {
+          key: 'over-permissioned',
+          label: 'Over-permissioned users',
+          count: input.overPermissionedCount,
+        },
+        { key: 'spof', label: 'Single-admin workspaces', count: input.spofCount },
+        {
+          key: 'spn',
+          label: 'Service principals with elevated roles',
+          count: input.spnElevatedCount,
+        },
+      ],
+    },
+    {
+      id: 'sharing',
+      title: 'Sharing',
+      question: 'What has left its workspace boundary?',
+      signals: [
+        {
+          key: 'widely-shared',
+          label: 'Items shared with the whole organization',
+          count: input.widelySharedCount,
+        },
+        {
+          key: 'unassigned-domain',
+          label: 'Workspaces outside any domain',
+          count: input.unassignedDomainCount,
+        },
+      ],
+    },
+    {
+      id: 'settings',
+      title: 'Settings',
+      question: 'Which tenant settings widen the blast radius?',
+      signals: [
+        {
+          key: 'risky-settings',
+          label: 'High-risk tenant settings enabled',
+          count: input.riskySettingsCount,
+        },
+      ],
+    },
+    {
+      id: 'lifecycle',
+      title: 'Lifecycle',
+      question: 'What is still provisioned but no longer used?',
+      signals: [
+        { key: 'ghost', label: 'Inactive workspaces', count: input.ghostCount },
+      ],
+    },
+  ];
+
+  return areas.map((area) => ({
+    ...area,
+    count: area.signals.reduce((sum, s) => sum + s.count, 0),
+    findingIds: input.findings
+      .filter((f) => (FINDING_AREA[f.id] ?? 'access') === area.id)
+      .map((f) => f.id),
+  }));
+}


### PR DESCRIPTION
Rebuilds the visual identity and re-plans every page's information architecture, per the approved
makeover spec. 18 commits, 30 files, +1126/-159.

## What changed

**Brand and tokens.** Primary swapped to cobalt `#2563EB` with a cyan secondary and a brand
gradient reserved for hero, wordmark, and primary CTA. Extrabold display headings, motion tokens.
The app routes all color through `--m-*` tokens, so this was largely a value swap that cascaded.

**Public surface (net-new).** `/` and `/about` now render in a marketing shell with its own nav and
footer; the dashboard moved to `/dashboard` and the sidebar shell wraps authenticated routes only.
New landing page: hero, four value props, a three-step how-it-works, closing CTA. The product
glimpse reuses the real `HealthGrid` over the demo tenant scored by the real
`calculateWorkspaceHealth`, so it cannot drift from the product.

**Information architecture.** Every page now leads with one answer, groups the secondary tier, and
puts raw data behind a fold:

- Security: posture and findings lead, then four drill-in areas (Access, Sharing, Settings,
  Lifecycle) from a new tested `groupSecurityAreas` helper; the user/workspace pivot moved behind a
  Directory fold. All twelve prior panels remain reachable.
- Dashboard: score, then HealthGrid, then issues; both distribution charts behind a fold.
- Workspaces: health column plus an at-risk count in the lead (this page had no health data before).
- Workspace detail: failed checks above the inventory counts.
- Capacity: active/paused and 24/7 list-price run rate in the lead, calculator behind a fold.

**Motion.** Health-grid tile stagger (20ms/tile, capped at 400ms) and a staggered hero entrance.
Tables stay instant.

## Accessibility

Audited every route in both themes with an in-page contrast checker. Five defects found, four of
which predate this branch or affect light mode:

| Issue | Was | Now |
|---|---|---|
| `--m-text-tertiary` on white (all helper text) | 3.32:1 | 5.03:1 via new `neutral-550` |
| Solid grade-D chips, both themes | 3.56:1 | 5.17:1 (`#EA580C` to `#C2410C`) |
| `--m-warning` as text; `--health-f` on its tint | 3.56 / 4.41 | 5.17 / 5.86 |
| Dark `primary-subtle` + `primary` pair | 4.07:1 | 5.77:1 via new `primary-950` |
| Solid primary buttons in dark (19 sites) | ~2.4:1 | 5.17:1 at the fill token |

Also fixed: `prefers-reduced-motion` zeroed animation duration but not delay, which would have held
staggered content invisible for up to 400ms. Two sub-24px hit targets enlarged.

Target size is enforced at the WCAG 2.2 AA bar (24x24), not the 44x44 in DESIGN_GUIDE.md, which is
AAA (SC 2.5.5) and would inflate every control in a dense admin table. Worth reconciling in the
guide either way.

## Deliberately not built

`useCountUp` (ScoreRing already count-ups, tested, and is the only consumer), a gradient ScoreRing
stroke (the stroke color is the grade signal), scroll-triggered section fades (needs an
IntersectionObserver), and sorting on the derived Health column.

## Verification

`npm run verify` green: lint, strict build, 159 unit tests, coverage floor, 13/13 Playwright e2e
with zero console errors on every route including `/`. Responsive checked at mobile, tablet, and
desktop with no horizontal overflow.