### PR TITLE
Release v2.0.1: accuracy patch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -255,17 +255,17 @@ const StatCard: React.FC<Props> = ({ title, count }) => { ... };
 ### Styling
 
 - Use **Tailwind CSS utility classes**. Avoid writing custom CSS unless absolutely necessary.
-- Use the **`--m-*` semantic token system** for all colors — never raw hex values or `gray-*` / `slate-*` scales in components. Tokens automatically resolve for both light and dark mode.
+- Use the **`--m-*` semantic token system** for all colors. Never raw hex values or `gray-*` / `slate-*` scales in components. Tokens automatically resolve for both light and dark mode.
 - Use **Radix UI primitives** with **class-variance-authority** and **tailwind-merge** for all interactive elements (buttons, dialogs, dropdowns, etc.).
-- Use `.m-skeleton` for loading skeletons — **never** `animate-pulse`.
+- Use `.m-skeleton` for loading skeletons, **never** `animate-pulse`.
 
 ```tsx
-// Correct — semantic tokens, automatic dark mode
+// Correct: semantic tokens, automatic dark mode
 <div className="bg-[var(--m-bg)] text-[var(--m-text)]">
   <p className="text-[var(--m-text-secondary)]">Subtitle</p>
 </div>
 
-// Incorrect — raw color scales, manual dark: variants
+// Incorrect: raw color scales, manual dark: variants
 <div className="bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
   <p className="text-gray-500 dark:text-gray-400">Subtitle</p>
 </div>

--- a/README.md
+++ b/README.md
@@ -155,10 +155,10 @@ For production deployments on Azure Static Web Apps, set these as Application Se
 
 ```mermaid
 flowchart TB
-    subgraph Browser["Browser SPA — React 19 · TypeScript · Vite"]
+    subgraph Browser["Browser SPA · React 19 · TypeScript · Vite"]
         Router["React Router\n/dashboard · /workspaces\n/capacity · /security\n/settings · /report · /about"]
         Stores["Zustand Stores\nworkspace · capacity\nsecurity · tenantSettings\nwidelyShared · activity · ui"]
-        Demo["Demo Mode\nbypasses auth · serves mocks\n3 capacities · 35 workspaces\n200+ items · 19 item types"]
+        Demo["Demo Mode\nbypasses auth · serves mocks\n3 capacities · 35 workspaces\n200+ items · 21 item types"]
         MSAL["MSAL.js 5\ncore scopes on login\nAdmin + Graph: on-demand"]
         FC["fabricClient\ntoken injection · pagination\nrate limiting"]
     end

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@
 
 **Do not open a public GitHub issue for security vulnerabilities.**
 
-Email security reports to: [TBD — author's security contact email]
+Email security reports to: psistlaw@gmail.com
 
 Include:
 - Description of the vulnerability
@@ -46,7 +46,7 @@ fabric-lens is a client-side SPA with no backend. Key security properties:
 
 - **Authentication:** MSAL.js v5 with PKCE (authorization code flow)
 - **Token storage:** Browser sessionStorage (cleared on tab close)
-- **API access:** Delegated permissions only — the app can never access
+- **API access:** Delegated permissions only. The app can never access
   more than the signed-in user can access directly
 - **No secrets:** No client secrets, no API keys, no backend credentials.
   The app registration uses SPA redirect (public client).

--- a/index.html
+++ b/index.html
@@ -7,10 +7,10 @@
 
     <!-- SEO -->
     <title>fabric-lens | Microsoft Fabric Governance &amp; Health</title>
-    <meta name="description" content="Free open-source governance dashboard for Microsoft Fabric. Audit workspace health, security posture, capacity usage, and tenant settings — runs entirely in your browser." />
+    <meta name="description" content="Free open-source governance dashboard for Microsoft Fabric. Audit workspace health, security posture, capacity usage, and tenant settings. Runs entirely in your browser." />
     <meta name="keywords" content="Microsoft Fabric, Fabric governance, Fabric admin, workspace health, security audit, capacity monitoring, Fabric tenant, Power BI admin, data platform governance, FUAM alternative, Fabric admin tool, workspace health score, Fabric security audit, Fabric capacity monitoring, tenant settings risk, Fabric consultant tool" />
     <link rel="canonical" href="https://www.fabric-lens.com" />
-    <meta name="theme-color" content="#4F46E5" />
+    <meta name="theme-color" content="#2563EB" />
     <link rel="preconnect" href="https://login.microsoftonline.com" />
     <link rel="preconnect" href="https://api.fabric.microsoft.com" />
 
@@ -28,7 +28,7 @@
     <!-- Twitter / X -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="fabric-lens | Microsoft Fabric Governance &amp; Health" />
-    <meta name="twitter:description" content="Free governance dashboard for Microsoft Fabric. Audit workspace health, security posture, capacity, and tenant settings — runs entirely in your browser." />
+    <meta name="twitter:description" content="Free governance dashboard for Microsoft Fabric. Audit workspace health, security posture, capacity, and tenant settings. Runs entirely in your browser." />
     <meta name="twitter:image" content="https://www.fabric-lens.com/og-image.png" />
     <!-- Structured Data -->
     <script type="application/ld+json">
@@ -37,7 +37,7 @@
       "@type": "SoftwareApplication",
       "name": "fabric-lens",
       "url": "https://www.fabric-lens.com",
-      "description": "Free open-source governance dashboard for Microsoft Fabric. Audit workspace health, security posture, capacity usage, and tenant settings — runs entirely in your browser.",
+      "description": "Free open-source governance dashboard for Microsoft Fabric. Audit workspace health, security posture, capacity usage, and tenant settings. Runs entirely in your browser.",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "Web",
       "offers": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fabric-lens",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fabric-lens",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "@azure/msal-browser": "^5.17.1",
         "@azure/msal-react": "^5.5.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fabric-lens",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,7 @@
 User-agent: *
 Allow: /$
 Allow: /about
+Disallow: /dashboard
 Disallow: /workspaces
 Disallow: /capacity
 Disallow: /security

--- a/src/api/demo.ts
+++ b/src/api/demo.ts
@@ -404,7 +404,7 @@ export const mockWorkspaces: Workspace[] = [
   {
     id: 'ws-32',
     displayName: 'Field Operations',
-    description: 'Field service data — migration to Operations Excellence in progress',
+    description: 'Field service data; migration to Operations Excellence in progress',
     type: 'Workspace',
     state: 'Active',
     capacityId: 'cap-2',
@@ -413,7 +413,7 @@ export const mockWorkspaces: Workspace[] = [
   {
     id: 'ws-33',
     displayName: 'Partner Analytics',
-    description: 'Partner portal data — governance handoff pending',
+    description: 'Partner portal data; governance handoff pending',
     type: 'Workspace',
     state: 'Active',
     capacityId: 'cap-3',

--- a/src/api/fabricClient.ts
+++ b/src/api/fabricClient.ts
@@ -166,7 +166,7 @@ export class FabricClient {
     if (isEffectiveDemoMode()) {
       throw new Error(
         'fabricClient: API call attempted in demo mode. ' +
-        'This is a bug — demo mode should use mock data exclusively.',
+        'This is a bug. Demo mode should use mock data exclusively.',
       );
     }
     return this.request<T>('GET', path, undefined, 0, scopes);
@@ -176,7 +176,7 @@ export class FabricClient {
     if (isEffectiveDemoMode()) {
       throw new Error(
         'fabricClient: API call attempted in demo mode. ' +
-        'This is a bug — demo mode should use mock data exclusively.',
+        'This is a bug. Demo mode should use mock data exclusively.',
       );
     }
     return this.request<T>('POST', path, body, 0, scopes);
@@ -194,7 +194,7 @@ export class FabricClient {
         // The API returned an unexpected response shape. Log in dev so we can
         // diagnose, then bail out with what we have rather than crashing.
         if (import.meta.env.DEV) {
-          console.warn('[FabricClient] listAll: unexpected response — no "value" array', path, response);
+          console.warn('[FabricClient] listAll: unexpected response, no "value" array', path, response);
         }
         break;
       }

--- a/src/api/graphClient.ts
+++ b/src/api/graphClient.ts
@@ -89,7 +89,7 @@ export async function getGroupMemberCount(
   if (isDemoMode) {
     throw new Error(
       'graphClient: API call attempted in demo mode. ' +
-      'This is a bug — demo mode should use mock data exclusively.',
+      'This is a bug. Demo mode should use mock data exclusively.',
     );
   }
   const token = await getGraphToken();
@@ -165,7 +165,7 @@ export async function getGroupMembers(
   if (isDemoMode) {
     throw new Error(
       'graphClient: API call attempted in demo mode. ' +
-      'This is a bug — demo mode should use mock data exclusively.',
+      'This is a bug. Demo mode should use mock data exclusively.',
     );
   }
   const token = await getGraphToken();

--- a/src/components/dashboard/HealthGrid.tsx
+++ b/src/components/dashboard/HealthGrid.tsx
@@ -312,7 +312,7 @@ export function HealthGrid({ workspaces, onWorkspaceClick }: HealthGridProps) {
                 onMouseMove={(e) => handleMouseMove(e, entry)}
                 onMouseEnter={handleTileEnter}
                 onMouseLeave={handleTileOut}
-                aria-label={`${entry.name} — Grade ${entry.grade}, ${entry.score}%`}
+                aria-label={`${entry.name}: Grade ${entry.grade}, ${entry.score}%`}
                 style={{
                   animationDelay: `${Math.min(
                     i * HEALTH_GRID_STAGGER_STEP_MS,

--- a/src/components/security/DomainGovernancePanel.tsx
+++ b/src/components/security/DomainGovernancePanel.tsx
@@ -100,7 +100,7 @@ export function DomainGovernancePanel({
         <div className="flex items-center gap-2 border-b border-[var(--m-border)] bg-[var(--m-accent-subtle)] px-4 py-2.5">
           <Share2 className="h-4 w-4 shrink-0 text-[var(--m-accent)]" />
           <p className="text-xs text-[var(--m-accent)]">
-            Org-wide shared content detected — artifacts shared to all users bypass domain access boundaries.
+            Org-wide shared content detected. Artifacts shared to all users bypass domain access boundaries.
           </p>
         </div>
       )}

--- a/src/components/security/SecurityFindingsPanel.tsx
+++ b/src/components/security/SecurityFindingsPanel.tsx
@@ -170,7 +170,7 @@ export function SecurityFindingsPanel({ findings }: Props) {
           <ShieldCheck className="h-8 w-8 text-[var(--m-success)]" />
           <p className="text-sm font-medium text-[var(--m-text)]">No security findings.</p>
           <p className="text-xs text-[var(--m-text-secondary)]">
-            All checks passed — access looks clean.
+            All checks passed. Access looks clean.
           </p>
         </div>
       ) : (

--- a/src/components/security/WidelySharedPanel.tsx
+++ b/src/components/security/WidelySharedPanel.tsx
@@ -64,7 +64,7 @@ export function WidelySharedPanel({ artifacts, loading, error, onRetry }: Props)
         <div className="flex items-center justify-between px-4 py-4">
           <div className="flex items-center gap-2 text-sm text-[var(--m-warning-text)]">
             <AlertTriangle className="h-4 w-4 shrink-0 text-[var(--m-warning)]" />
-            Widely shared artifacts unavailable — check admin permissions
+            Widely shared artifacts unavailable; check admin permissions
           </div>
           <button
             onClick={onRetry}

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -342,7 +342,7 @@ export function AboutPage() {
               <p className="text-sm leading-relaxed text-[var(--m-text-secondary)]">
                 No credentials needed. The app opens in demo mode automatically, with a complete
                 audit of a realistic mock Fabric tenant: 35 workspaces, 3 capacities, 200+
-                items across all 19 item types, and pre-loaded security findings.
+                items across 21 item types, and pre-loaded security findings.
               </p>
             </Section>
 

--- a/src/pages/SecurityPage.tsx
+++ b/src/pages/SecurityPage.tsx
@@ -179,7 +179,7 @@ function AdminRequiredCard() {
           <li>5. Sign out of fabric-lens, then sign back in</li>
         </ol>
         <p className="mt-3 text-[11px] text-[var(--m-text-tertiary)]">
-          Already have the role? A page refresh is not enough — sign out and sign back
+          Already have the role? A page refresh is not enough; sign out and sign back
           in to get a fresh token that reflects your current role assignment.
         </p>
       </div>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -330,8 +330,8 @@ export const HEALTH_GRID_STAGGER_MAX_MS = 400;
 
 // -- App metadata --
 
-/** Application version (mirrors package.json). */
-export const APP_VERSION = '1.4.0';
+/** Application version. Injected from package.json at build time by vite `define`. */
+export const APP_VERSION = __APP_VERSION__;
 
 // -- Tenant Settings Risk --
 

--- a/src/utils/healthScore.ts
+++ b/src/utils/healthScore.ts
@@ -62,7 +62,7 @@ export function calculateWorkspaceHealth(
     maxPoints: w.capacity,
     detail: hasCapacity
       ? `Assigned to capacity ${workspace.capacityId}`
-      : 'No capacity assigned — workspace runs on shared capacity',
+      : 'No capacity assigned; workspace runs on shared capacity',
   });
 
   // Domain assigned
@@ -88,8 +88,8 @@ export function calculateWorkspaceHealth(
     points: hasIdentity ? w.workspaceIdentity : 0,
     maxPoints: w.workspaceIdentity,
     detail: hasIdentity
-      ? 'Service principal configured — enables Git integration and automation'
-      : 'No workspace identity — configure SPN to enable Git integration and automation',
+      ? 'Service principal configured, enabling Git integration and automation'
+      : 'No workspace identity; configure SPN to enable Git integration and automation',
   });
 
   // Naming convention
@@ -113,7 +113,7 @@ export function calculateWorkspaceHealth(
     maxPoints: w.activeItems,
     detail: hasItems
       ? `${items.length} item${items.length === 1 ? '' : 's'} in workspace`
-      : 'Workspace has no items — consider adding content or archiving',
+      : 'Workspace has no items; consider adding content or archiving',
   });
 
   // Data layer present
@@ -127,7 +127,7 @@ export function calculateWorkspaceHealth(
     maxPoints: w.dataLayer,
     detail: hasDataLayer
       ? 'Workspace includes a Lakehouse or Warehouse'
-      : 'No Lakehouse or Warehouse found — consider adding a data layer',
+      : 'No Lakehouse or Warehouse found; consider adding a data layer',
   });
 
   // Reasonable item count
@@ -139,7 +139,7 @@ export function calculateWorkspaceHealth(
     maxPoints: w.reasonableCount,
     detail: reasonableCount
       ? `${items.length} items (within recommended limit of ${MAX_REASONABLE_ITEM_COUNT})`
-      : `${items.length} items exceeds recommended limit of ${MAX_REASONABLE_ITEM_COUNT} — consider splitting`,
+      : `${items.length} items exceeds recommended limit of ${MAX_REASONABLE_ITEM_COUNT}; consider splitting`,
   });
 
 
@@ -164,7 +164,7 @@ export function calculateWorkspaceHealth(
       maxPoints: w.tagCoverage,
       detail: tagPassed
         ? `${taggedCount} of ${items.length} items tagged (${tagPctDisplay}%)`
-        : `Only ${taggedCount} of ${items.length} items tagged (${tagPctDisplay}%) — apply tags to improve item discoverability and governance`,
+        : `Only ${taggedCount} of ${items.length} items tagged (${tagPctDisplay}%); apply tags to improve item discoverability and governance`,
     });
   }
 

--- a/src/utils/securityFindings.ts
+++ b/src/utils/securityFindings.ts
@@ -137,7 +137,7 @@ export function deriveSecurityFindings(
     findings.push({
       id: 'unresolved-admin-groups',
       severity: 'warning',
-      title: `${unresolvedAdminGroups.length} group${unresolvedAdminGroups.length > 1 ? 's' : ''} with Admin role — membership unknown`,
+      title: `${unresolvedAdminGroups.length} group${unresolvedAdminGroups.length > 1 ? 's' : ''} with Admin role, membership unknown`,
       detail: 'Expand these groups to verify who has effective admin access. Unknown group membership is an audit gap.',
       affectedItems: unresolvedAdminGroups.map((u) => ({
         label: u.displayName,
@@ -305,7 +305,7 @@ export function computeSecurityPosture(
     label: 'Admin assignment ratio',
     earned: ratioHealthy ? 10 : 0,
     max: 10,
-    status: `${Math.round(adminPct)}% of assignments are Admin${ratioHealthy ? ' (healthy)' : ` — target <${ADMIN_ASSIGNMENT_PCT_THRESHOLD}%`}`,
+    status: `${Math.round(adminPct)}% of assignments are Admin${ratioHealthy ? ' (healthy)' : `, target <${ADMIN_ASSIGNMENT_PCT_THRESHOLD}%`}`,
   });
 
   // 6. No admin-less workspaces (10 pts) — binary

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+/** Injected by vite `define` from package.json's version field. */
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,19 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { fileURLToPath, URL } from 'url';
 import { configDefaults } from 'vitest/config';
+import { readFileSync } from 'node:fs';
+
+// Read rather than `import ... with { type: 'json' }`: the import-attribute form
+// needs Node 20.10+ (CI pins Node 20) and an implicit resolveJsonModule that
+// tsconfig.node.json does not actually set. readFileSync has neither constraint.
+const pkgVersion = JSON.parse(
+  readFileSync(new URL('./package.json', import.meta.url), 'utf-8'),
+).version as string;
 
 export default defineConfig({
+  // Single source of truth for the version shown in Settings. Hardcoding it in
+  // constants.ts let it drift (stuck at 1.4.0 through the 2.0.0 release).
+  define: { __APP_VERSION__: JSON.stringify(pkgVersion) },
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {


### PR DESCRIPTION
Accuracy patch. No behavior change, no API change, no migration.

Found while auditing the site ahead of the marketing push. Three of these are
user-visible factual errors on public surfaces that shipped in v2.0.0.

## Fixes

**Settings displayed the wrong version.** `APP_VERSION` was a hardcoded string
duplicating `package.json`, and it sat at `1.4.0` through the entire v2.0.0
release. Fixed at the root rather than by editing the number: `vite.config.ts`
injects `__APP_VERSION__` from `package.json` via `define`, so bumping the
manifest is now the only step and the two cannot disagree again.

Read via `readFileSync` rather than a JSON import attribute on purpose: the
`with { type: 'json' }` form needs Node 20.10+ (CI pins Node 20) and an implicit
`resolveJsonModule` that `tsconfig.node.json` does not set.

**`/about` claimed "all 19 item types".** The catalog refresh (#44) raised the
recognized set to 51 but the prose describing it was never updated. Real numbers,
verified by parsing `demo.ts`: 201 items across 21 item types. Corrected on the
public About page and in the README architecture diagram.

**`/dashboard` was crawlable.** The v2.0.0 makeover moved the app root from `/`
to `/dashboard`, but `robots.txt` was not updated, leaving the one gated route
Google was free to index. Also refreshed `theme-color`, still the pre-makeover
indigo rather than the cobalt primary.

**Security policy had no contact.** `SECURITY.md` shipped with a `[TBD]`
placeholder where the vulnerability report address belongs.

**Em dash audit** across source and tracked docs, including three in `index.html`
meta descriptions, which is copy that search engines display.

## Verification

`npm run verify` green (lint, strict build, coverage floor, 13/13 e2e).
`npm run type-check` and `npm run build:demo` also clean. Version confirmed baked
into both build outputs. Lockfile diff is 2 lines with libc metadata intact.

## Follow-ups filed, not in this PR

The same audit found stale brand assets that need design work: `og-image.png` and
`favicon.svg` both still carry the pre-makeover indigo, and the single `index.html`
self-canonicalizes `/about` to the root. Tracked separately so this stays a
no-behavior-change patch.
