### PR TITLE
Consolidate ignore rules, track screenshot script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,21 +16,13 @@ dist-ssr
 *.swp
 *.swo
 
-# Claude Code
-.claude/
+# Local workspace, not part of the project
+/.local/
 CLAUDE.md
+.claude/
 .superpowers/
-
-# Understand Anything knowledge graph (generated output)
 .understand-anything/
-
-# Git worktrees
 .worktrees/
-DESIGN_GUIDE.md
-
-# Meridian design system reference files (local only — copy from your design system repo)
-meridian-tokens.css
-meridian-prompt-stem.md
 
 # OS
 .DS_Store
@@ -42,20 +34,6 @@ npm-debug.log*
 
 # TypeScript
 *.tsbuildinfo
-
-# Audit reports
-SECURITY_AUDIT.md
-
-# Local planning docs
-SECURITY_PAGE_PLAN.md
-STRATEGY.md
-TASKS*.md
-NEXT.md
-AUTONOMY.md
-docs/superpowers/
-
-# Local dev scripts
-scripts/
 
 # Playwright
 /test-results/

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
+    "screenshots": "node scripts/screenshots.mjs",
     "verify": "npm run lint && npm run build && npm run test:coverage && npm run test:e2e"
   },
   "dependencies": {

--- a/scripts/screenshots.mjs
+++ b/scripts/screenshots.mjs
@@ -1,0 +1,49 @@
+import { chromium } from '@playwright/test';
+import { mkdirSync } from 'node:fs';
+
+const OUT = 'docs/screenshots';
+const BASE = 'http://localhost:5173';
+
+const SHOTS = [
+  { file: 'landing.png', path: '/', theme: 'light' },
+  { file: 'dashboard.png', path: '/dashboard', theme: 'light' },
+  { file: 'workspaces.png', path: '/workspaces', theme: 'light' },
+  { file: 'capacity.png', path: '/capacity', theme: 'light' },
+  { file: 'security.png', path: '/security', theme: 'light', scan: true },
+  { file: 'dashboard-dark.png', path: '/dashboard', theme: 'dark' },
+];
+
+mkdirSync(OUT, { recursive: true });
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({
+  viewport: { width: 1440, height: 900 },
+  deviceScaleFactor: 2,
+});
+const page = await ctx.newPage();
+
+for (const shot of SHOTS) {
+  await page.goto(BASE + shot.path, { waitUntil: 'networkidle' });
+
+  // Theme lives in the persisted ui store; set it before the app paints so we
+  // never screenshot a mid-transition frame.
+  await page.evaluate((theme) => {
+    const raw = localStorage.getItem('fabric-lens-ui');
+    const parsed = raw ? JSON.parse(raw) : { state: {}, version: 0 };
+    parsed.state = { ...parsed.state, theme };
+    localStorage.setItem('fabric-lens-ui', JSON.stringify(parsed));
+  }, shot.theme);
+  await page.reload({ waitUntil: 'networkidle' });
+
+  if (shot.scan) {
+    const scan = page.getByRole('button', { name: /^Scan All$/ }).last();
+    await scan.click();
+    await page.waitForTimeout(4000);
+  }
+
+  await page.waitForTimeout(1200); // let entrance animations settle
+  await page.screenshot({ path: `${OUT}/${shot.file}` });
+  console.log('captured', shot.file, shot.theme);
+}
+
+await browser.close();


### PR DESCRIPTION
Repo hygiene. No application code, no behavior change.

## Ignore file no longer names private documents

The ignore file listed each local planning document by name, under a heading
reading `# Local planning docs`:

```
SECURITY_PAGE_PLAN.md
STRATEGY.md
TASKS*.md
NEXT.md
AUTONOMY.md
docs/superpowers/
```

Plus `SECURITY_AUDIT.md` under `# Audit reports`. That told anyone browsing the
repo which private documents exist. On a governance and security tool, an
advertised-but-hidden `SECURITY_AUDIT.md` invites exactly the wrong question.

Three of those rules were already dead, pointing at files retired months ago.

All planning now lives in one local folder, so a single neutral rule covers it
and no filename needs to appear here again.

## scripts/ is now partly tracked

`scripts/screenshots.mjs` generates the six screenshots committed under
`docs/screenshots/`. It was ignored, which left a tracked artifact
non-reproducible by anyone else. Now tracked, with `npm run screenshots`.

The two puppeteer-based scripts are deliberately excluded: puppeteer is not in
`package.json` and is not installed, so neither could run. One was superseded by
the Playwright version kept here; the other needs porting before it is worth
committing.

## Verification

`npm run verify` green (lint, strict build, coverage floor, 13/13 e2e).
Confirmed no local planning file is staged, and that the moved folder is still
ignored after the rewrite.
