### PR TITLE
Pre-release polish: /about SEO pass + DCO note

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,10 @@ most review comments before they happen: run `npm run build` rather than `type-c
 build catches unused locals and parameters), and put every threshold, color, and magic number in
 `src/utils/constants.ts` instead of inlining it.
 
+Commits need a `Signed-off-by` line, which `git commit -s` adds for you. That is the
+[DCO](CONTRIBUTING.md#5-sign-off-your-commits-dco), not a CLA; there is no paperwork and you keep
+the copyright to your own work.
+
 <details>
 <summary>All scripts</summary>
 

--- a/src/hooks/usePageMeta.test.tsx
+++ b/src/hooks/usePageMeta.test.tsx
@@ -22,6 +22,8 @@ describe('usePageMeta', () => {
       <meta name="twitter:title" content="Root title" />
       <meta name="twitter:description" content="Root description." />
     `;
+    // After head.innerHTML, since replacing it drops the <title> element.
+    document.title = 'fabric-lens';
   });
 
   it('points canonical and og:url at the route', () => {
@@ -30,10 +32,16 @@ describe('usePageMeta', () => {
     expect(ogUrl()).toBe('https://www.fabric-lens.com/about');
   });
 
+  it('sets document.title to the given title verbatim', () => {
+    render(<Probe />);
+    expect(document.title).toBe('About');
+  });
+
   it('restores the root values on unmount', () => {
     const { unmount } = render(<Probe />);
     unmount();
     expect(canonical()).toBe('https://www.fabric-lens.com');
     expect(ogUrl()).toBe('https://www.fabric-lens.com');
+    expect(document.title).toBe('fabric-lens');
   });
 });

--- a/src/hooks/usePageMeta.ts
+++ b/src/hooks/usePageMeta.ts
@@ -5,7 +5,7 @@ const SITE = 'https://www.fabric-lens.com';
 interface PageMeta {
   /** Route path, e.g. '/about'. Becomes the canonical and og:url. */
   path: string;
-  /** Full page title. Also used for og:title and twitter:title. */
+  /** Full page title. Sets document.title as well as og:title and twitter:title. */
   title: string;
   description: string;
 }
@@ -40,10 +40,16 @@ export function usePageMeta({ path, title, description }: PageMeta) {
       ['meta[name="twitter:description"]', 'content', setAttr('meta[name="twitter:description"]', 'content', description)],
     ] as const;
 
+    // Owns document.title too, so the crafted SEO title is what ships in <title>.
+    // Pages using this must NOT also call useDocumentTitle, which would win the race.
+    const previousTitle = document.title;
+    document.title = title;
+
     return () => {
       for (const [selector, attr, previous] of restore) {
         if (previous !== null) setAttr(selector, attr, previous);
       }
+      document.title = previousTitle;
     };
   }, [path, title, description]);
 }

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,4 +1,3 @@
-import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { usePageMeta } from '@/hooks/usePageMeta';
 import { GITHUB_URL, GITHUB_ISSUES_URL } from '@/utils/constants';
 import {
@@ -51,17 +50,16 @@ const toc = [
   { id: 'capabilities', label: 'Key capabilities' },
   { id: 'how-to-use', label: 'How to use this site' },
   { id: 'requirements', label: 'What you need for a tenant audit' },
-  { id: 'health-scoring', label: 'Health scoring explained' },
-  { id: 'security-audit', label: 'Security audit explained' },
+  { id: 'health-scoring', label: 'Workspace health scoring' },
+  { id: 'security-audit', label: 'Tenant security audit' },
   { id: 'demo-mode', label: 'Demo mode' },
   { id: 'links', label: 'Links' },
 ];
 
 export function AboutPage() {
-  useDocumentTitle('About');
   usePageMeta({
     path: '/about',
-    title: 'About fabric-lens | How health scoring and the security audit work',
+    title: 'Microsoft Fabric governance and tenant auditing | fabric-lens',
     description:
       'How fabric-lens scores workspace health, what the security audit checks, which Fabric REST APIs it calls, and why it runs entirely in your browser with no backend.',
   });
@@ -94,10 +92,11 @@ export function AboutPage() {
             {/* Page title */}
             <div>
               <h1 className="mb-3 text-3xl font-bold text-[var(--m-text)]">
-                About fabric-lens
+                About fabric-lens: Microsoft Fabric governance and tenant auditing
               </h1>
               <p className="text-base leading-relaxed text-[var(--m-text-secondary)]">
-                A reference guide for Fabric admins and consultants.
+                How workspace health scoring, the security audit, and capacity monitoring work,
+                and what access each one needs.
               </p>
             </div>
 
@@ -241,7 +240,7 @@ export function AboutPage() {
             </Section>
 
             {/* Health scoring */}
-            <Section id="health-scoring" title="Health scoring explained">
+            <Section id="health-scoring" title="Fabric workspace health scoring explained">
               <p className="mb-4 text-sm leading-relaxed text-[var(--m-text-secondary)]">
                 Every workspace is scored across nine governance checks, worth a combined maximum of
                 110 points when the workspace has items (100 points when empty; tag coverage is
@@ -300,7 +299,7 @@ export function AboutPage() {
             </Section>
 
             {/* Security audit */}
-            <Section id="security-audit" title="Security audit explained">
+            <Section id="security-audit" title="Fabric tenant security audit explained">
               <p className="mb-4 text-sm leading-relaxed text-[var(--m-text-secondary)]">
                 The security audit runs when you click "Scan All" on the Security page. It requires
                 Fabric Administrator role for most checks. The overall posture score is a weighted


### PR DESCRIPTION
Two pre-launch items, batched so one PR covers them.

## /about SEO content pass

Technical SEO (canonical, og:url, per-route meta, sitemap lastmod) already shipped in #49. This is the content and structure half.

- **H1** was `About fabric-lens`, a branded phrase with near-zero search volume in the strongest on-page slot. Now `About fabric-lens: Microsoft Fabric governance and tenant auditing`, still honestly an about page.
- **Subtitle** names what the page actually documents: health scoring, the security audit, capacity monitoring, and the access each needs.
- **Section headings** requalified: `Health scoring explained` and `Security audit explained` said neither "Fabric" nor "workspace". Anchor ids are unchanged, so existing links still resolve.
- **`<title>` fix.** `usePageMeta` documented `title` as the full page title but only applied it to og:title/twitter:title; `useDocumentTitle` set the real `<title>` to `About | fabric-lens`. The hook now owns `document.title` and restores the previous value on unmount, same as it does for canonical and og:url. `/about` is its only caller.

Deliberately skipped: JSON-LD `FAQPage` (Google cut FAQ rich results back to mostly gov/health in 2023), and the intro rewrite (its first sentence already leads with the searchable phrasing).

The remaining ceiling is that `/about` is client-rendered; prerendering is tracked separately.

## README

Notes the DCO sign-off requirement for contributions.

## Verification

- `npm run lint` — 0 errors (4 pre-existing fast-refresh warnings)
- `npm run build` — clean
- `npm run test` — 162 passed, including 2 new assertions covering the title set and its restore
- Checked in a browser: `/about` renders with the new title and `…/about` canonical, and both revert to the site defaults on navigating away