### PR TITLE
feat(seo): prerender the public routes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      # Ahead of the build, not just ahead of the e2e step: `npm run build`
+      # triggers postbuild -> scripts/prerender.mjs, which drives a real browser.
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
       - name: Build (strict TypeScript)
         run: npm run build
         env:
@@ -52,11 +57,18 @@ jobs:
           VITE_FABRIC_API_BASE: https://api.fabric.microsoft.com/v1
           VITE_ARM_API_BASE: https://management.azure.com
 
+      # Captured HERE, immediately after the production build, because the e2e
+      # step below runs build:demo and overwrites dist with a demo-mode build.
+      # Uploading any later would ship demo mode to fabric-lens.com.
+      - name: Upload built site
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist
+          retention-days: 1
+
       - name: Test + coverage floor
         run: npm run test:coverage
-
-      - name: Install Playwright browser
-        run: npx playwright install --with-deps chromium
 
       - name: E2E (Playwright, demo build)
         run: npm run test:e2e
@@ -72,10 +84,11 @@ jobs:
           retention-days: 7
 
   # ── Deploy ─────────────────────────────────────────────────────────────────
-  # On PR: deploys to an Azure SWA preview environment. GitHub posts the
-  #        preview URL as a PR comment — use it for end-to-end testing before
-  #        merging. Demo mode works immediately; for auth testing add the
-  #        preview URL to the Azure AD App Registration redirect URIs.
+  # On PR: deploys to an Azure SWA preview environment. The URL is NOT posted
+  #        as a PR comment; read it from this job's log, last line of the
+  #        deploy step ("Visit your site at: ..."). Demo mode works
+  #        immediately; for auth testing add the preview URL to the Azure AD
+  #        App Registration redirect URIs.
   # On merge to master: deploys to the production site (fabric-lens.com).
   # Always requires the CI gate to pass first.
   deploy:
@@ -95,22 +108,34 @@ jobs:
           submodules: true
           lfs: false
 
-      - name: Build and Deploy
+      # The site is built once, in the ci job, and shipped from that artifact.
+      # Oryx must NOT rebuild here: it has no browser, so the prerender step in
+      # postbuild would fail, and a partial success would leave the SWA rewrites
+      # pointing at snapshots that were never generated. Deploying the artifact
+      # also means production gets the exact bytes the tests ran against.
+      - name: Download built site
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_LIVELY_GRASS_0FA393E10 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
-          app_location: "/"
+          skip_app_build: true
+          # With skip_app_build, app_location is the prebuilt output and
+          # output_location must be empty.
+          app_location: "dist"
           api_location: ""
-          output_location: "dist"
-        env:
-          VITE_MSAL_CLIENT_ID: ${{ secrets.VITE_MSAL_CLIENT_ID }}
-          VITE_MSAL_TENANT_ID: common
-          VITE_MSAL_REDIRECT_URI: https://fabric-lens.com
-          VITE_FABRIC_API_BASE: https://api.fabric.microsoft.com/v1
-          VITE_ARM_API_BASE: https://management.azure.com
+          output_location: ""
+          # config_file_location defaults to app_location. staticwebapp.config.json
+          # lives at the repo root, so without this the CSP headers and the
+          # prerender rewrites would silently stop shipping.
+          config_file_location: "/"
 
   # ── Cleanup ─────────────────────────────────────────────────────────────────
   # Tears down the PR preview environment when the pull request is closed.

--- a/e2e/prerender.spec.ts
+++ b/e2e/prerender.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+
+// The snapshots exist so crawlers and unfurl bots see content without running
+// JS, so these assert the RAW response body via request (no browser boot). In
+// production staticwebapp.config.json rewrites / and /about onto these files;
+// vite preview does not apply SWA rewrites, hence the .html paths here.
+const SNAPSHOTS = [
+  { file: '/home.html', text: 'Know what your Fabric tenant is' },
+  { file: '/about.html', text: 'About fabric-lens: Microsoft Fabric governance and tenant auditing' },
+];
+
+for (const { file, text } of SNAPSHOTS) {
+  test(`${file} ships rendered HTML`, async ({ request }) => {
+    const html = await (await request.get(file)).text();
+    expect(html).toContain(text);
+    expect(html).not.toContain('<div id="root"></div>');
+  });
+}
+
+test('index.html stays an empty shell for the SPA fallback', async ({ request }) => {
+  // Every authenticated route falls back to this file. If prerendered markup
+  // ever lands here, /dashboard flashes the landing page before React boots.
+  const html = await (await request.get('/index.html')).text();
+  expect(html).toContain('<div id="root"></div>');
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "postbuild": "npm run prerender",
     "build:demo": "vite build --mode demo",
+    "postbuild:demo": "npm run prerender",
+    "prerender": "node scripts/prerender.mjs",
     "preview": "vite preview",
     "lint": "eslint .",
     "type-check": "tsc --noEmit",

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -1,0 +1,46 @@
+import { chromium } from '@playwright/test';
+import { preview } from 'vite';
+import { writeFileSync } from 'node:fs';
+
+// Snapshots the two PUBLIC routes into static HTML so crawlers and unfurl bots
+// get real content instead of an empty <div id="root">. Runs after `vite build`
+// against the freshly built dist.
+//
+// These are crawler payload, not a hydration contract: main.tsx uses createRoot
+// (not hydrateRoot), so React clears #root and re-renders from scratch on boot.
+// There is no markup to keep in sync and no mismatch to get wrong.
+//
+// dist/index.html is deliberately LEFT ALONE — it stays the clean SPA fallback
+// for every authenticated route. staticwebapp.config.json rewrites / and /about
+// to these two files instead. See scripts/og-image.mjs for the same
+// launch-render-capture pattern.
+
+const PORT = 4174;
+const PAGES = [
+  { path: '/', out: 'dist/home.html' },
+  { path: '/about', out: 'dist/about.html' },
+];
+
+const server = await preview({
+  preview: { port: PORT, strictPort: true, host: '127.0.0.1' },
+});
+
+const browser = await chromium.launch();
+const ctx = await browser.newContext({
+  // Pin both so the snapshot is deterministic. reducedMotion also settles the
+  // entrance animations, which otherwise capture mid-fade at opacity 0.
+  colorScheme: 'light',
+  reducedMotion: 'reduce',
+});
+const page = await ctx.newPage();
+
+for (const { path, out } of PAGES) {
+  await page.goto(`http://127.0.0.1:${PORT}${path}`, { waitUntil: 'networkidle' });
+  await page.waitForSelector('#root h1');
+  const html = await page.evaluate(() => document.documentElement.outerHTML);
+  writeFileSync(out, `<!DOCTYPE html>\n${html}\n`);
+  console.log('prerendered', path, '->', out);
+}
+
+await browser.close();
+await server.close();

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -10,6 +10,11 @@
     "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
     "X-DNS-Prefetch-Control": "off"
   },
+  "_prerenderNotes": "The two public routes are prerendered by scripts/prerender.mjs and served from static snapshots so crawlers and unfurl bots get real HTML. These are rewrites, not redirects, so the URL stays / and /about. index.html is left as the empty SPA shell for every other route.",
+  "routes": [
+    { "route": "/", "rewrite": "/home.html" },
+    { "route": "/about", "rewrite": "/about.html" }
+  ],
   "navigationFallback": {
     "rewrite": "/index.html",
     "exclude": ["/assets/*", "/*.{svg,png,ico,xml,txt}", "/auth.html"]


### PR DESCRIPTION
Crawlers, unfurl bots, and the LLM crawlers were served an empty `<div id="root"></div>` on `/` and `/about`. Every word on both pages was created by JS after boot. Google renders JS on a deferred second pass; Bing, LinkedIn, Slack, and most LLM crawlers do not.

## What changed

`scripts/prerender.mjs` runs after `vite build`: serves the built `dist`, opens both public routes in headless Chromium, waits for paint, writes the resulting DOM to `dist/home.html` and `dist/about.html`. `staticwebapp.config.json` rewrites `/` and `/about` onto those files. URLs are unchanged and React still boots on top, so nothing changes for a human visitor.

`/about` goes from 3.5 kB of empty shell to 33.6 kB carrying the real H1, the section headings, the body copy, and the crafted `<title>` and canonical.

No new dependencies. Playwright and Vite are both already devDependencies, and this reuses the launch-render-capture pattern from `scripts/og-image.mjs`.

## Why `index.html` is untouched

`navigationFallback` serves `index.html` for every unmatched route, which is how `/dashboard` and `/security` resolve. A snapshot written there would flash the landing page on every authenticated route before React corrected it. The snapshots are therefore separate files, and `e2e/prerender.spec.ts` asserts `index.html` still contains an empty `#root`.

Safe because `main.tsx` uses `createRoot`, not `hydrateRoot`: React clears the container and re-renders, so there is no hydration contract and no mismatch class of bug.

## Verification

`npm run verify` green: lint, strict build, coverage floor, 16/16 e2e. Three new e2e tests assert the raw response body rather than a booted page, since the point is what a non-JS client receives.

The two SWA rewrites cannot be exercised locally (`vite preview` ignores `staticwebapp.config.json`). Checking them on the preview environment is the remaining step.

## Deliberately not done

No `/about.html` to `/about` redirect. A redirect onto a path that itself rewrites back to `.html` risks a loop on the main SEO page, and the canonical inside the snapshot already handles duplicate content.