### PR TITLE
chore(deps): clear high severity advisories

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20]
+        # 22, not 20: react-router 8 declares engines.node >=22.22.0.
+        node-version: [22]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,18 +18,20 @@ jobs:
     name: Security, Lint, Build & Test
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # 22, not 20: react-router 8 declares engines.node >=22.22.0.
-        node-version: [22]
+    # No build matrix. It only ever held one Node version, but its value was
+    # appended to the job name, so the branch protection rule on master pinned
+    # the check as "Security, Lint, Build & Test (20)". Bumping Node renamed the
+    # check and left the required one permanently unreportable, blocking merges.
+    # Without a matrix the name is stable and Node can move freely.
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js ${{ matrix.node-version }}
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          # 22, not 20: react-router 8 declares engines.node >=22.22.0.
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "fabric-lens",
       "version": "2.1.0",
+      "license": "MIT",
       "dependencies": {
         "@azure/msal-browser": "^5.17.1",
         "@azure/msal-react": "^5.5.3",
@@ -19,7 +20,7 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-is": "^19.2.7",
-        "react-router": "^7.14.2",
+        "react-router": "^8.3.0",
         "recharts": "^3.9.2",
         "tailwind-merge": "^3.6.0",
         "zustand": "^5.0.14"
@@ -2368,16 +2369,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -2473,18 +2474,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3871,9 +3865,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -4075,9 +4069,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "dev": true,
       "funding": [
         {
@@ -4095,7 +4089,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4209,20 +4203,19 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -4367,12 +4360,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-is": "^19.2.7",
-    "react-router": "^7.14.2",
+    "react-router": "^8.3.0",
     "recharts": "^3.9.2",
     "tailwind-merge": "^3.6.0",
     "zustand": "^5.0.14"

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "target": "ES2020",
+    "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,8 +6,8 @@ import { configDefaults } from 'vitest/config';
 import { readFileSync } from 'node:fs';
 
 // Read rather than `import ... with { type: 'json' }`: the import-attribute form
-// needs Node 20.10+ (CI pins Node 20) and an implicit resolveJsonModule that
-// tsconfig.node.json does not actually set. readFileSync has neither constraint.
+// needs an implicit resolveJsonModule that tsconfig.node.json does not actually
+// set. readFileSync has no such constraint.
 const pkgVersion = JSON.parse(
   readFileSync(new URL('./package.json', import.meta.url), 'utf-8'),
 ).version as string;


### PR DESCRIPTION
`npm audit --audit-level=high` reports three high advisories on the current lockfile. That step runs first in the CI gate, so it is currently failing every PR on the repo, including unrelated ones. Master is red for the same reason.

| Package | Advisory | Resolution |
|---|---|---|
| `brace-expansion` | DoS via unbounded expansion | patch bump to 5.0.8 |
| `postcss` | Path traversal in sourcemap auto-loading | patch bump |
| `react-router` 7.18.1 | RSC-mode CSRF bypass | v8.3.0 |

## Why react-router went to v8

There is no patched 7.x. The advisory range is `7.12.0 - 8.2.0`, and 7.18.2 (the newest 7) is inside it. The options were v8, a downgrade to 7.11.0 that npm itself calls breaking, or suppressing the finding.

The advisory is not reachable here. It concerns RSC mode, and this is a client-side SPA with no server, no server actions, and no RSC. But with no patched 7.x available, keeping it would have meant carrying a permanent audit suppression in the CI of a security tool.

**The upgrade required no application code changes.** Every v8 breaking change lands on framework/data mode (loaders, actions, meta, middleware, `hasErrorBoundary`) or on the `react-router-dom` package that v8 removed. This codebase imports from `react-router` directly and uses only `BrowserRouter`, `MemoryRouter`, `Routes`, `Route`, `Outlet`, `Link`, `NavLink`, `useNavigate`, `useLocation`, `useParams`.

What v8 did require:
- **CI matrix Node 20 to 22.** v8 declares `engines.node >=22.22.0`.
- **`tsconfig.app.json` target and lib ES2020 to ES2022.** v8 raised the floor.
- React 19.2.7+ and Vite 7+ were already satisfied.

The stale "CI pins Node 20" note in `vite.config.ts` was corrected; the other reason that comment gives for `readFileSync` still stands, so the code is unchanged.

## Verification

`npm run verify` green: lint, strict build, coverage floor, 13/13 e2e. `npm audit` now reports 0 vulnerabilities.

The e2e suite covers every route including the two public ones, so the router swap is exercised end to end.

## Lockfile note

`npm install` on Windows strips the `libc` markers from Linux-only optional packages, which breaks resolution in Linux CI. Those 10 entries were restored, and the remaining lockfile diff is only the real dependency changes.