### PR TITLE
fix(deps): patch two high severity advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2372,9 +2372,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4651,9 +4651,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## What

Bumps two vulnerable transitive dev dependencies in `package-lock.json` only:

| Package | Via | From | To | Advisory |
|---|---|---|---|---|
| `brace-expansion` | `eslint` → `minimatch` | 5.0.8 | 5.0.9 | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) |
| `undici` | `jsdom` | 7.28.0 | 7.29.0 | [GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524) + 4 more |

## Why

`npm audit --audit-level=high` began failing on `master` after the advisories were published on 2026-08-04. Because that step runs before lint, build, and test, every open Dependabot PR (#63, #64, #65) is red for a reason unrelated to its own change. Nothing merges until this lands.

Both packages are `"dev": true` and neither ships in the browser bundle, so this is a CI blocker rather than a production exposure.

## Why a hand-edited lockfile

`npm audit fix` and `npm update brace-expansion undici` both report "up to date" and change nothing, even with `--prefer-online` — npm will not re-resolve a transitive whose pinned version still satisfies its parent's range. A full `npm install --package-lock-only` does resolve correctly, but regenerating on Windows drops all 10 `libc` entries and sweeps in 6 unrelated packages across a 1384-line diff, which breaks Linux CI.

Editing the two entries in place gives the same resolution in +6/-6 lines. Both targets were already inside their parents' declared ranges (`minimatch` wants `^5.0.8`, `jsdom` wants `^7.25.0`), so no `package.json` change is needed.

## Verification

- `npm ci` syncs without rewriting the lockfile
- `npm audit --audit-level=high` → `found 0 vulnerabilities`
- `libc` entries intact at 10
- Resolved: `brace-expansion@5.0.9`, `undici@7.29.0`
- `npm run verify` green — lint, strict build, coverage floor, 16/16 Playwright e2e

## Follow-ups

- Closes #65 as superseded (it carried the undici half alone and could not go green on its own)
- #63 and #64 should rebase clean once this merges. #64 is a jsdom **major** and needs a local `npm run verify` before merge, not a rubber stamp
- `package-lock.json` on `master` still reports version 2.2.0 while `package.json` says 2.3.0; left alone here to keep the diff surgical
