### PR TITLE
fix(deps): patch high severity nanoid advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3802,9 +3802,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
`nanoid@3.3.16` is affected by GHSA-2v37-7h3g-55p8 (high): custom generators can loop indefinitely when size is zero. It reaches the tree as `vite -> postcss -> nanoid`.

`npm audit --audit-level=high` runs first in the CI job, so this blocked every PR on the repo, not just this one.

postcss pins `nanoid@^3.3.16`, so 3.3.18 fits inside the existing range and neither postcss nor vite moves. The `version`, `resolved` and `integrity` fields were hand-edited on the existing lockfile entry rather than regenerated, because regenerating on Windows strips all 14 `libc` blocks that the Linux CI runners rely on to select platform binaries.

Verified locally: `npm ci` leaves the lockfile untouched, `npm audit` reports 0 vulnerabilities, lint has 0 errors, the strict build passes, and 176 tests across 19 files pass.