### PR TITLE
chore: drop dead analytics comment

### DIFF
--- a/src/components/marketing/MarketingFooter.tsx
+++ b/src/components/marketing/MarketingFooter.tsx
@@ -6,8 +6,7 @@ import { GITHUB_URL } from '@/utils/constants';
  *
  * The privacy line states what is architecturally true today: fabric-lens is a
  * client-side SPA that calls Fabric APIs straight from the browser, so tenant
- * data never reaches a server of ours. Revisit this wording if the Cloudflare
- * analytics beacon lands on the public shell.
+ * data never reaches a server of ours.
  */
 export function MarketingFooter() {
   return (


### PR DESCRIPTION
The doc comment on `MarketingFooter` asked a future reader to revisit the privacy wording if the Cloudflare analytics beacon landed on the public shell. Analytics was killed on 2026-08-07, so the beacon is not coming and the question is settled.

The footer copy itself is untouched and remains accurate: it is scoped to tenant data, which no analytics decision was ever going to change.

Comment-only change, no behaviour difference.