### PR TITLE
feat: item colour families, target sizes, and CI actions

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,7 +18,7 @@ jobs:
     # ever land on the default branch.
     # ─────────────────────────────────────────────────────────────────────────
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/dependency-review-action@v4
+      - uses: actions/checkout@v7
+      - uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,10 +25,10 @@ jobs:
     # Without a matrix the name is stable and Node can move freely.
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           # 22, not 20: react-router 8 declares engines.node >=22.22.0.
           node-version: 22
@@ -61,7 +61,7 @@ jobs:
       # step below runs build:demo and overwrites dist with a demo-mode build.
       # Uploading any later would ship demo mode to fabric-lens.com.
       - name: Upload built site
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload Playwright artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-artifacts
           path: |
@@ -103,7 +103,7 @@ jobs:
       (github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed'))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: true
           lfs: false
@@ -114,7 +114,7 @@ jobs:
       # pointing at snapshots that were never generated. Deploying the artifact
       # also means production gets the exact bytes the tests ran against.
       - name: Download built site
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fabric-lens",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fabric-lens",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-browser": "^5.18.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fabric-lens",
   "private": true,
-  "version": "2.3.0",
+  "version": "2.4.0",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -48,6 +48,39 @@ check('README item-type count matches KnownItemType', () => {
   }
 });
 
+// --- Item colour families vs their CSS tokens -------------------------------
+// ItemTypeBadge composes `var(--item-${token})` at runtime, so a family in the
+// map with no matching token in index.css yields an unstyled badge rather than
+// an error. Lives here and not in a unit test because Vitest cannot read the
+// stylesheet: the Tailwind v4 plugin intercepts `.css`, and `?raw` comes back
+// empty.
+check('every item colour family has tokens in both themes', () => {
+  const constants = readFileSync('src/utils/constants.ts', 'utf8');
+  const map = constants.match(/const ITEM_TYPE_TOKENS[\s\S]*?\n\};/);
+  if (!map) throw new Error('could not locate ITEM_TYPE_TOKENS');
+
+  const families = new Set([...map[0].matchAll(/:\s*'([a-z-]+)'/g)].map((m) => m[1]));
+  families.add('default'); // itemTypeToken's fallback, never a map value
+
+  const css = readFileSync('src/index.css', 'utf8');
+  const rootAt = css.indexOf(':root {');
+  const darkAt = css.indexOf('.dark {');
+  if (rootAt === -1 || darkAt === -1) throw new Error('could not locate :root / .dark blocks');
+  const themes = { light: css.slice(rootAt, darkAt), dark: css.slice(darkAt) };
+
+  const missing = [];
+  for (const family of families) {
+    for (const [theme, block] of Object.entries(themes)) {
+      for (const suffix of ['', '-bg']) {
+        if (!block.includes(`--item-${family}${suffix}:`)) {
+          missing.push(`--item-${family}${suffix} (${theme})`);
+        }
+      }
+    }
+  }
+  if (missing.length > 0) throw new Error(`undefined tokens: ${missing.join(', ')}`);
+});
+
 // --- The backlog's current-release line -------------------------------------
 // Drifted for four releases (v2.0.1 through v2.3.0) before anyone noticed, because
 // the top of the backlog is read far more often than it is edited. .local/ is

--- a/src/components/marketing/MarketingFooter.tsx
+++ b/src/components/marketing/MarketingFooter.tsx
@@ -25,7 +25,7 @@ export function MarketingFooter() {
         <nav className="flex flex-col gap-2 text-sm">
           <Link
             to="/about"
-            className="text-[var(--m-text-secondary)] transition-colors duration-[120ms] hover:text-[var(--m-text)]"
+            className="-my-1 py-1 text-[var(--m-text-secondary)] transition-colors duration-[120ms] hover:text-[var(--m-text)]"
           >
             About
           </Link>
@@ -33,7 +33,7 @@ export function MarketingFooter() {
             href={GITHUB_URL}
             target="_blank"
             rel="noreferrer"
-            className="text-[var(--m-text-secondary)] transition-colors duration-[120ms] hover:text-[var(--m-text)]"
+            className="-my-1 py-1 text-[var(--m-text-secondary)] transition-colors duration-[120ms] hover:text-[var(--m-text)]"
           >
             Source on GitHub
           </a>

--- a/src/components/marketing/MarketingNav.tsx
+++ b/src/components/marketing/MarketingNav.tsx
@@ -30,7 +30,7 @@ export function MarketingNav() {
         <div className="ml-auto flex items-center gap-5">
           <Link
             to="/about"
-            className="hidden text-sm text-[var(--m-text-secondary)] transition-colors duration-[120ms] hover:text-[var(--m-text)] sm:inline"
+            className="-my-1 hidden py-1 text-sm text-[var(--m-text-secondary)] transition-colors duration-[120ms] hover:text-[var(--m-text)] sm:inline"
           >
             About
           </Link>
@@ -38,7 +38,7 @@ export function MarketingNav() {
             href={GITHUB_URL}
             target="_blank"
             rel="noreferrer"
-            className="hidden text-sm text-[var(--m-text-secondary)] transition-colors duration-[120ms] hover:text-[var(--m-text)] sm:inline"
+            className="-my-1 hidden py-1 text-sm text-[var(--m-text-secondary)] transition-colors duration-[120ms] hover:text-[var(--m-text)] sm:inline"
           >
             GitHub
           </a>
@@ -74,7 +74,7 @@ export function MarketingNav() {
                     );
                   });
                 }}
-                className="whitespace-nowrap text-sm font-medium text-[var(--m-text-secondary)] transition-colors duration-[120ms] hover:text-[var(--m-text)]"
+                className="-my-1 whitespace-nowrap py-1 text-sm font-medium text-[var(--m-text-secondary)] transition-colors duration-[120ms] hover:text-[var(--m-text)]"
               >
                 Sign in
               </button>

--- a/src/index.css
+++ b/src/index.css
@@ -119,6 +119,10 @@
   --item-report:         #B45309;  /* Amber   — accent        */
   --item-semantic-model: #DB2777;  /* Pink                    */
   --item-dashboard:      #EA580C;  /* Orange  — warning       */
+  --item-rti:            #4D7C0F;  /* Lime    — real-time     */
+  --item-ai:             #A21CAF;  /* Fuchsia — AI / DS       */
+  --item-industry:       #BE123C;  /* Rose    — industry      */
+  --item-platform:       #0F766E;  /* Teal    — platform/apps */
   --item-default:        #495057;  /* Gray    — neutral-600   */
 
   /* ─── FABRIC-LENS EXTENSIONS: Item Type Backgrounds ─────── */
@@ -129,6 +133,10 @@
   --item-report-bg:         #FFFBEB;
   --item-semantic-model-bg: #FDF2F8;
   --item-dashboard-bg:      #FFF7ED;
+  --item-rti-bg:            #F7FEE7;
+  --item-ai-bg:             #FDF4FF;
+  --item-industry-bg:       #FFF1F2;
+  --item-platform-bg:       #F0FDFA;
   --item-default-bg:        var(--m-surface);
 
   /* ─── FABRIC-LENS EXTENSIONS: Roles ─────────────────────── */
@@ -295,6 +303,10 @@
   --item-report:         #FBBF24;  /* amber-400 */
   --item-semantic-model: #F472B6;  /* pink-400 */
   --item-dashboard:      #FB923C;  /* orange-400 */
+  --item-rti:            #A3E635;  /* lime-400 */
+  --item-ai:             #E879F9;  /* fuchsia-400 */
+  --item-industry:       #FB7185;  /* rose-400 */
+  --item-platform:       #2DD4BF;  /* teal-400 */
   --item-default:        #ADB5BD;  /* neutral-400 */
   --item-lakehouse-bg:      rgba(79, 70, 229, 0.15);
   --item-notebook-bg:       rgba(124, 58, 237, 0.15);
@@ -303,6 +315,10 @@
   --item-report-bg:         rgba(180, 83, 9, 0.15);
   --item-semantic-model-bg: rgba(219, 39, 119, 0.15);
   --item-dashboard-bg:      rgba(234, 88, 12, 0.15);
+  --item-rti-bg:            rgba(77, 124, 15, 0.15);
+  --item-ai-bg:             rgba(162, 28, 175, 0.15);
+  --item-industry-bg:       rgba(190, 18, 60, 0.15);
+  --item-platform-bg:       rgba(15, 118, 110, 0.15);
   --item-default-bg:        rgba(73, 80, 87, 0.15);
 
   /* Legacy alias overrides for dark mode */

--- a/src/utils/__tests__/itemTypeToken.test.ts
+++ b/src/utils/__tests__/itemTypeToken.test.ts
@@ -1,17 +1,25 @@
 import { describe, it, expect } from 'vitest';
 import { itemTypeToken } from '../constants';
 
+// The matching --item-* tokens are checked against index.css by
+// `npm run docs:check`; Vitest cannot read the stylesheet.
 describe('itemTypeToken', () => {
   it('maps known workloads to a color token by family', () => {
     expect(itemTypeToken('Lakehouse')).toBe('lakehouse');
     expect(itemTypeToken('Report')).toBe('report');
-    // newer GA workloads resolve to a family token, not gray
-    expect(itemTypeToken('DataAgent')).toBe('notebook');
-    expect(itemTypeToken('Eventhouse')).toBe('warehouse');
+    expect(itemTypeToken('DataAgent')).toBe('ai');
+    expect(itemTypeToken('Eventhouse')).toBe('rti');
+    expect(itemTypeToken('AppBackend')).toBe('platform');
   });
 
-  it('falls back to default (gray) for unmapped / future types', () => {
-    expect(itemTypeToken('AppBackend')).toBe('default');
+  it('gives real-time intelligence its own family, not warehouse', () => {
+    // The whole point of the split: an Eventstream must not look like a Warehouse.
+    expect(itemTypeToken('Eventstream')).not.toBe(itemTypeToken('Warehouse'));
+    expect(itemTypeToken('KQLDashboard')).not.toBe(itemTypeToken('Dashboard'));
+    expect(itemTypeToken('MLModel')).not.toBe(itemTypeToken('Notebook'));
+  });
+
+  it('falls back to default (gray) only for types outside the union', () => {
     expect(itemTypeToken('SomeWorkloadShippedNextYear')).toBe('default');
   });
 });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -105,12 +105,16 @@ export const CHART_FALLBACK_COLOR = '#495057';
 // -- Item types --
 
 /**
- * Maps a Fabric item type to an existing `--item-*` color token suffix (see
- * index.css for the light/dark values). Related workloads share the eight
- * established tokens by family; unknown/long-tail types fall through to
- * 'default' (neutral gray) in {@link itemTypeToken}.
- * // ponytail: family-reuse of the 8 existing tokens; the makeover (Phase 3
- * // item 2) replaces this with a per-workload signature palette.
+ * Maps a Fabric item type to an `--item-*` color token suffix (see index.css
+ * for the light/dark values). Related workloads share a token by family, one
+ * family per Fabric workload group. Every member of `KnownItemType` is mapped;
+ * 'default' (neutral gray) is reserved for the open union's long tail — item
+ * types Microsoft adds after this list was written.
+ *
+ * Families are grouped, not per-type: the badge renders the type name, so color
+ * carries the workload grouping rather than the identity. A per-type palette
+ * would need 51 hues that stay distinguishable AND pass contrast on both
+ * themes, for no added information.
  */
 const ITEM_TYPE_TOKENS: Record<string, string> = {
   // Power BI
@@ -145,18 +149,33 @@ const ITEM_TYPE_TOKENS: Record<string, string> = {
   CosmosDBDatabase: 'warehouse',
   AzureDatabricksStorage: 'warehouse',
   // Real-time intelligence
-  Eventhouse: 'warehouse',
-  Eventstream: 'warehouse',
-  KQLDatabase: 'warehouse',
-  KQLQueryset: 'warehouse',
-  KQLDashboard: 'warehouse',
-  Reflex: 'warehouse',
+  Eventhouse: 'rti',
+  Eventstream: 'rti',
+  KQLDatabase: 'rti',
+  KQLQueryset: 'rti',
+  KQLDashboard: 'rti',
+  Reflex: 'rti',
+  EventSchemaSet: 'rti',
   // AI / data science
-  DataAgent: 'notebook',
-  MLExperiment: 'notebook',
-  MLModel: 'notebook',
-  GraphModel: 'notebook',
-  GraphQuerySet: 'notebook',
+  DataAgent: 'ai',
+  MLExperiment: 'ai',
+  MLModel: 'ai',
+  GraphModel: 'ai',
+  GraphQuerySet: 'ai',
+  AnomalyDetector: 'ai',
+  // Industry solutions / digital twin
+  DigitalTwinBuilder: 'industry',
+  DigitalTwinBuilderFlow: 'industry',
+  Ontology: 'industry',
+  Map: 'industry',
+  // Developer surfaces and org apps
+  GraphQLApi: 'platform',
+  UserDataFunction: 'platform',
+  AppBackend: 'platform',
+  VariableLibrary: 'platform',
+  OrgApp: 'platform',
+  OrgAppAudience: 'platform',
+  OperationsAgent: 'platform',
 };
 
 /** Color token suffix for a Fabric item type; 'default' for unmapped types. */


### PR DESCRIPTION
Clears the queued housekeeping list and gives every Fabric item type a colour. Released as v2.4.0;
the colour work is user visible, so this is a minor rather than a patch.

## Item colour families

The catalog recognised 51 item types but only 38 mapped to a colour, and the families were coarse
enough to be misleading: `warehouse` carried 17 of the 38 keys, absorbing the whole
warehouse/database/mirroring group *and* all of real time intelligence, so an Eventstream rendered
identically to a Warehouse. `notebook` carried 8, doing the same to AI and data science.

Four new token families: `rti` lime, `ai` fuchsia, `industry` rose, `platform` teal. All 51 union
members now map, so nothing renders grey. Grey is now reserved for the open union's long tail,
meaning item types Microsoft ships after this list was written. `warehouse` drops from 17 keys to
11, `notebook` from 8 to 3, and the largest family is 11.

Families stay grouped rather than per type because `ItemTypeBadge` renders the type name, so the
colour carries the workload and not the identity. A 51 colour palette would need 51 hues that stay
distinguishable and pass contrast in both themes, for no added information.

Two measurements behind the palette rather than eyeballing:

* **Contrast.** All four new families clear AA (4.5:1) against both their own tint and the surface,
  in both themes. Worst case is 4.74.
* **Perceptual spacing.** Every pair introduced here is further apart than two pairs that already
  ship. The tightest new pair is `pipeline`/`rti` at dE 23.1, against a shipped `report`/`dashboard`
  at 22.7.

`developer` and `org-app` were merged into one `platform` family. A fifth distinct hue lands near
217 degrees, which is primary cobalt `#2563EB`, and an item badge in near primary blue reads as
clickable.

## Marketing shell target sizes

Five controls under the 24x24 baseline of WCAG 2.2 SC 2.5.8, deliberately left out of #62 to keep
that diff off a surface #60 had just reworked: `About`, `GitHub` and `Sign in` in `MarketingNav`,
plus both links in `MarketingFooter`. Each grows from 20px to 28px tall using the `-my-1 py-1` idiom
already shipped in `HealthGrid`.

Layout is unchanged, confirmed by measuring the page with and without the diff: header height 78px
both ways, document height 2478px both ways, footer link spacing 28px both ways. `landing.png` did
not need regenerating. Inline links inside prose are left alone, since SC 2.5.8 exempts them.

## GitHub Actions off Node 20

Five actions across eight call sites. The backlog recorded this as a bump to `@v5`, which would not
have worked: `upload-artifact@v5` still defaulted to Node 20, and `download-artifact@v6` had only
preliminary support. Each target was picked by reading `runs.using` from the action's own
`action.yml` at that tag rather than trusting the release notes, which is also how
`checkout@v5` turned out to already be Node 24 despite a stale line in its changelog.

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-node` | v4 | v7 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `actions/dependency-review-action` | v4 | v5 |

`Azure/static-web-apps-deploy@v1` is unaffected; v1 is current for that one.

Breaking changes checked against the inputs this repo actually passes. `setup-node@v6` limits
automatic caching to npm, and `cache: npm` is already pinned here. `download-artifact@v8` now errors
on a digest mismatch instead of warning, and skips decompression based on `Content-Type`; uploads
here are zipped by default, so they decompress normally. `upload-artifact@v7` and
`download-artifact@v8` are the matched pair. `checkout@v7`'s new fork restriction applies to
`pull_request_target` and `workflow_run`, and this repo uses `pull_request`.

## Verification

`npm run verify` green: 3 doc checks, lint, strict build, 177 unit tests, 16/16 Playwright e2e.

Both colour splits were confirmed in the running app on `/workspaces/ws-18` in both themes:
`Eventstream` and `KQLDatabase` render lime against `SQLEndpoint` cyan, and `MLModel` renders
fuchsia against `Notebook` violet.

`docs:check` gains a third check, that every colour family has its four `--item-*` declarations
across light and dark. `ItemTypeBadge` composes `var(--item-${token})` at runtime, so a family with
no token renders unstyled rather than raising an error. It lives in `check-docs.mjs` instead of a
unit test because Vitest cannot read the stylesheet: the Tailwind v4 plugin intercepts `.css`, and
`?raw` comes back empty. Both that check and the unit test were mutation tested.

## Not addressed

Three shipped colours fail AA in light mode against their own tint at 11px: `warehouse` 3.54,
`dashboard` 3.35, `semantic-model` 4.21. The least distinguishable pair in the system is also
pre-existing, `lakehouse` against `notebook`, at dE 14.4 light and 11.3 dark. Both predate this work
and fixing either means changing colours that already ship, so they are tracked separately.
