### PR TITLE
feat: naming pattern persistence, item colour AA, and a docs check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fabric-lens",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fabric-lens",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-browser": "^5.18.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fabric-lens",
   "private": true,
-  "version": "2.4.0",
+  "version": "2.5.0",
   "license": "MIT",
   "type": "module",
   "scripts": {

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -81,6 +81,61 @@ check('every item colour family has tokens in both themes', () => {
   if (missing.length > 0) throw new Error(`undefined tokens: ${missing.join(', ')}`);
 });
 
+// --- The DESIGN_GUIDE item palette ------------------------------------------
+// Drifted 2026-08-11: v2.4.0 added four families and this list still showed
+// eight the next day, while CLAUDE.md step 10 sends every design audit to it.
+// Checks hex values and not just names, because the second drift (2026-08-17)
+// was three colours darkened for AA while every family name stayed put.
+// .local/ is gitignored, so this skips cleanly in CI.
+check('DESIGN_GUIDE item palette matches index.css', () => {
+  if (!existsSync('.local/DESIGN_GUIDE.md')) return 'no .local/DESIGN_GUIDE.md';
+
+  const constants = readFileSync('src/utils/constants.ts', 'utf8');
+  const map = constants.match(/const ITEM_TYPE_TOKENS[\s\S]*?\n\};/);
+  if (!map) throw new Error('could not locate ITEM_TYPE_TOKENS');
+  const families = new Set([...map[0].matchAll(/:\s*'([a-z-]+)'/g)].map((m) => m[1]));
+  families.add('default');
+
+  const css = readFileSync('src/index.css', 'utf8');
+  const rootAt = css.indexOf(':root {');
+  const darkAt = css.indexOf('.dark {');
+  if (rootAt === -1 || darkAt === -1) throw new Error('could not locate :root / .dark blocks');
+  const light = css.slice(rootAt, darkAt);
+
+  // Both sides parsed with the same literal. An earlier version built this
+  // regex with `new RegExp(`...\s*...`)`, where the template literal ate the
+  // backslash, so it matched nothing and the check passed vacuously.
+  const palette = (text) =>
+    new Map(
+      [...text.matchAll(/--item-([a-z-]+):\s*(#[0-9A-Fa-f]{6})/g)].map((m) => [
+        m[1],
+        m[2].toUpperCase(),
+      ]),
+    );
+
+  const guide = readFileSync('.local/DESIGN_GUIDE.md', 'utf8');
+  const shipped = palette(light);
+  const documented = palette(guide);
+
+  const problems = [];
+  for (const family of families) {
+    const actual = shipped.get(family);
+    if (!actual) continue; // check 3 already owns missing tokens
+    const claimed = documented.get(family);
+    if (!claimed) problems.push(`--item-${family} missing from DESIGN_GUIDE`);
+    else if (claimed !== actual) {
+      problems.push(`--item-${family}: DESIGN_GUIDE says ${claimed}, index.css has ${actual}`);
+    }
+  }
+
+  const stated = guide.match(/\/\* (\d+) families as of/);
+  if (stated && Number(stated[1]) !== families.size) {
+    problems.push(`DESIGN_GUIDE states ${stated[1]} families, there are ${families.size}`);
+  }
+
+  if (problems.length > 0) throw new Error(problems.join('; '));
+});
+
 // --- The backlog's current-release line -------------------------------------
 // Drifted for four releases (v2.0.1 through v2.3.0) before anyone noticed, because
 // the top of the backlog is read far more often than it is edited. .local/ is

--- a/src/components/report/ReportCover.tsx
+++ b/src/components/report/ReportCover.tsx
@@ -1,4 +1,6 @@
 import type { ReportData } from '@/utils/reportData';
+import { useHealthConfigStore } from '@/store/healthConfigStore';
+import { DEFAULT_NAMING_PATTERN_STRING } from '@/utils/constants';
 
 interface Props {
   data: Pick<ReportData,
@@ -8,6 +10,10 @@ interface Props {
 }
 
 export function ReportCover({ data }: Props) {
+  const namingPattern = useHealthConfigStore((s) => s.namingPattern);
+  const customNamingPattern =
+    namingPattern === DEFAULT_NAMING_PATTERN_STRING ? null : namingPattern;
+
   const dateStr = data.generatedAt.toLocaleDateString('en-GB', {
     day: 'numeric', month: 'long', year: 'numeric',
   });
@@ -29,6 +35,15 @@ export function ReportCover({ data }: Props) {
           <p className="mt-3 text-sm text-[var(--m-text-secondary)]">
             Generated {dateStr} · fabric-lens.com
           </p>
+          {customNamingPattern && (
+            // Scores in this report were produced with a non-default naming
+            // pattern, so they will not match a report run with the shipped
+            // defaults. Say so on the page rather than letting two reports
+            // silently disagree.
+            <p className="mt-2 text-xs text-[var(--m-text-secondary)]">
+              Custom naming pattern: <code className="font-mono">{customNamingPattern}</code>
+            </p>
+          )}
         </div>
         <div className="text-center bg-[var(--m-bg)] rounded-xl px-6 py-4">
           <p className="text-[11px] font-semibold text-[var(--m-text-secondary)] uppercase tracking-[0.06em]">

--- a/src/components/security/GhostWorkspacesPanel.tsx
+++ b/src/components/security/GhostWorkspacesPanel.tsx
@@ -5,6 +5,7 @@ import type { GhostWorkspace } from '@/utils/ghostWorkspaces';
 import type { Workspace } from '@/api/types/workspace';
 import type { Item } from '@/api/types/item';
 import { calculateWorkspaceHealth } from '@/utils/healthScore';
+import { useNamingPattern } from '@/hooks/useNamingPattern';
 import type { HealthGrade } from '@/utils/healthScore';
 import { GHOST_WORKSPACE_THRESHOLD_DAYS, ACTIVITY_LOG_LOOKBACK_DAYS } from '@/utils/constants';
 
@@ -56,6 +57,8 @@ export function GhostWorkspacesPanel({
   scanProgress,
   onRetry,
 }: Props) {
+  const namingPattern = useNamingPattern();
+
   // Build a lookup map from workspaceId → Workspace for health grade computation
   const workspaceMap = useMemo(
     () => new Map(workspaces.map((w) => [w.id, w])),
@@ -208,7 +211,7 @@ export function GhostWorkspacesPanel({
             {sorted.map((ghost) => {
               const workspace = workspaceMap.get(ghost.workspaceId);
               const grade = workspace
-                ? calculateWorkspaceHealth(workspace, allItemsByWorkspace[ghost.workspaceId] ?? []).grade
+                ? calculateWorkspaceHealth(workspace, allItemsByWorkspace[ghost.workspaceId] ?? [], namingPattern).grade
                 : 'F';
 
               return (

--- a/src/hooks/useNamingPattern.ts
+++ b/src/hooks/useNamingPattern.ts
@@ -1,0 +1,12 @@
+import { useMemo } from 'react';
+import {
+  useHealthConfigStore,
+  compileNamingPattern,
+} from '@/store/healthConfigStore';
+
+/** The user's naming-convention pattern, compiled. Every surface that scores a
+ *  workspace reads it from here so a Settings change moves all of them at once. */
+export function useNamingPattern(): RegExp {
+  const pattern = useHealthConfigStore((s) => s.namingPattern);
+  return useMemo(() => compileNamingPattern(pattern), [pattern]);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -115,15 +115,22 @@
   --item-lakehouse:      #4F46E5;  /* Indigo  — primary       */
   --item-notebook:       #7C3AED;  /* Violet                  */
   --item-pipeline:       #15803D;  /* Green   — success       */
-  --item-warehouse:      #0891B2;  /* Cyan                    */
+  --item-warehouse:      #0E7490;  /* Cyan    — cyan-700      */
   --item-report:         #B45309;  /* Amber   — accent        */
-  --item-semantic-model: #DB2777;  /* Pink                    */
-  --item-dashboard:      #EA580C;  /* Orange  — warning       */
+  --item-semantic-model: #BE185D;  /* Pink    — pink-700      */
+  --item-dashboard:      #BF310D;  /* Orange  — see note below */
   --item-rti:            #4D7C0F;  /* Lime    — real-time     */
   --item-ai:             #A21CAF;  /* Fuchsia — AI / DS       */
   --item-industry:       #BE123C;  /* Rose    — industry      */
   --item-platform:       #0F766E;  /* Teal    — platform/apps */
   --item-default:        #495057;  /* Gray    — neutral-600   */
+  /* Three light-mode colours were darkened 2026-08-17 to clear WCAG AA (4.5:1) against
+     their own tints at 11px: warehouse 3.54, semantic-model 4.21, dashboard 3.35.
+     warehouse and semantic-model took the Tailwind 700 step. dashboard could not:
+     orange-700 is #C2410C, which is already --health-d and --m-warning, and
+     --health-d-bg is the same #FFF7ED tint, so a D grade and a Dashboard badge would
+     have rendered identically. #BF310D is hand-picked at hue 12 instead, which also
+     opens the dashboard/report gap from 5.5 to 14 degrees. Dark mode was unaffected. */
 
   /* ─── FABRIC-LENS EXTENSIONS: Item Type Backgrounds ─────── */
   --item-lakehouse-bg:      #EEF2FF;

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -1,5 +1,10 @@
 import { usePageMeta } from '@/hooks/usePageMeta';
-import { GITHUB_URL, GITHUB_ISSUES_URL } from '@/utils/constants';
+import {
+  GITHUB_URL,
+  GITHUB_ISSUES_URL,
+  HEALTH_SCORE_WEIGHTS,
+  MAX_REASONABLE_ITEM_COUNT,
+} from '@/utils/constants';
 import {
   ShieldCheck,
   LayoutDashboard,
@@ -33,16 +38,20 @@ interface TableRow {
   note?: string;
 }
 
+// Points come from HEALTH_SCORE_WEIGHTS rather than being written out here.
+// This table is public, prerendered documentation of how scoring works, and the
+// hand-copied version drifted: it claimed Semantic Models counted as a data
+// layer and that 100 items failed the count check. Neither was true.
 const healthChecks: TableRow[] = [
-  { criterion: 'Assigned to a capacity', points: 15, note: 'Critical' },
-  { criterion: 'Workspace identity configured (SPN + Git)', points: 25, note: 'Critical' },
-  { criterion: 'Has a description', points: 10, note: 'Critical' },
-  { criterion: 'Assigned to a domain', points: 10 },
-  { criterion: 'Follows naming convention', points: 10 },
-  { criterion: 'Contains at least one item', points: 10 },
-  { criterion: 'Includes a data layer (Lakehouse/Warehouse/Semantic Model)', points: 10 },
-  { criterion: 'Reasonable item count (< 100)', points: 10 },
-  { criterion: 'Tag coverage ≥ 80% of items', points: 10, note: 'Skipped if no items' },
+  { criterion: 'Assigned to a capacity', points: HEALTH_SCORE_WEIGHTS.capacity, note: 'Critical' },
+  { criterion: 'Workspace identity configured (SPN + Git)', points: HEALTH_SCORE_WEIGHTS.workspaceIdentity, note: 'Critical' },
+  { criterion: 'Has a description', points: HEALTH_SCORE_WEIGHTS.description, note: 'Critical' },
+  { criterion: 'Assigned to a domain', points: HEALTH_SCORE_WEIGHTS.domain },
+  { criterion: 'Follows naming convention', points: HEALTH_SCORE_WEIGHTS.naming },
+  { criterion: 'Contains at least one item', points: HEALTH_SCORE_WEIGHTS.activeItems },
+  { criterion: 'Includes a data layer (Lakehouse/Warehouse)', points: HEALTH_SCORE_WEIGHTS.dataLayer },
+  { criterion: `Reasonable item count (≤ ${MAX_REASONABLE_ITEM_COUNT})`, points: HEALTH_SCORE_WEIGHTS.reasonableCount },
+  { criterion: 'Tag coverage ≥ 80% of items', points: HEALTH_SCORE_WEIGHTS.tagCoverage, note: 'Skipped if no items' },
 ];
 
 const toc = [

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -295,7 +295,7 @@ export function AboutPage() {
                   { grade: 'B', label: '≥ 80%', color: 'bg-[#4F46E5] text-white' },
                   { grade: 'C', label: '≥ 65%', color: 'bg-[#B45309] text-white' },
                   { grade: 'D', label: '≥ 50%', color: 'bg-[#C2410C] text-white' },
-                  { grade: 'F', label: '< 50%', color: 'bg-[#DC2626] text-white' },
+                  { grade: 'F', label: '< 50%', color: 'bg-[#B91C1C] text-white' },
                 ].map(({ grade, label, color }) => (
                   <div key={grade} className="flex items-center gap-2">
                     <span className={`flex h-7 w-7 items-center justify-center rounded-lg text-sm font-bold ${color}`}>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -23,7 +23,8 @@ import { useUiStore } from '@/store/uiStore';
 import { StatCard } from '@/components/shared/StatCard';
 import { GovernanceIssuesPanel } from '@/components/dashboard/GovernanceIssuesPanel';
 import { aggregateGovernanceIssues } from '@/utils/governanceIssues';
-import { calculateWorkspaceHealth } from '@/utils/healthScore';
+import { calculateWorkspaceHealth, getGrade } from '@/utils/healthScore';
+import { useNamingPattern } from '@/hooks/useNamingPattern';
 import type { HealthScore } from '@/utils/healthScore';
 import { ExportButton } from '@/components/shared/ExportButton';
 import { CollapsibleSection } from '@/components/shared/CollapsibleSection';
@@ -31,18 +32,10 @@ import { HealthGrid } from '@/components/dashboard/HealthGrid';
 import { SecurityQuickView } from '@/components/dashboard/SecurityQuickView';
 import { ScoreRing } from '@/components/dashboard/ScoreRing';
 import { exportToJSON } from '@/utils/export';
-import { CHART_COLORS, CHART_FALLBACK_COLOR, CHART_TOOLTIP_STYLE, GRADE_THRESHOLDS, HEALTH_GRADE_COLORS, BENCHMARK_HEALTH_SCORE } from '@/utils/constants';
+import { CHART_COLORS, CHART_FALLBACK_COLOR, CHART_TOOLTIP_STYLE, HEALTH_GRADE_COLORS, BENCHMARK_HEALTH_SCORE } from '@/utils/constants';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 
 const GRADE_ORDER = ['F', 'D', 'C', 'B', 'A'] as const;
-
-function getGrade(score: number): string {
-  if (score >= GRADE_THRESHOLDS.A) return 'A';
-  if (score >= GRADE_THRESHOLDS.B) return 'B';
-  if (score >= GRADE_THRESHOLDS.C) return 'C';
-  if (score >= GRADE_THRESHOLDS.D) return 'D';
-  return 'F';
-}
 
 export function DashboardPage() {
   useDocumentTitle('Dashboard');
@@ -86,6 +79,8 @@ export function DashboardPage() {
     [allItemsByWorkspace],
   );
 
+  const namingPattern = useNamingPattern();
+
   // Health results map — computed once, drives all health-derived data
   const { healthMap, healthError } = useMemo((): {
     healthMap: Map<string, HealthScore>;
@@ -95,7 +90,7 @@ export function DashboardPage() {
       const map = new Map<string, HealthScore>(
         workspaces.map((ws) => {
           const wsItems = allItemsByWorkspace[ws.id] ?? [];
-          return [ws.id, calculateWorkspaceHealth(ws, wsItems)];
+          return [ws.id, calculateWorkspaceHealth(ws, wsItems, namingPattern)];
         }),
       );
       return { healthMap: map, healthError: null };
@@ -106,7 +101,7 @@ export function DashboardPage() {
           err instanceof Error ? err.message : 'Health score computation failed',
       };
     }
-  }, [workspaces, allItemsByWorkspace]);
+  }, [workspaces, allItemsByWorkspace, namingPattern]);
 
   // Tenant-level score, grade, and at-risk count
   const { tenantScore, tenantGrade, atRiskCount } = useMemo(() => {
@@ -210,7 +205,7 @@ export function DashboardPage() {
       },
       workspaces: workspaces.map((ws) => {
         const wsItems = allItemsByWorkspace[ws.id] ?? [];
-        const health = calculateWorkspaceHealth(ws, wsItems);
+        const health = calculateWorkspaceHealth(ws, wsItems, namingPattern);
         const cap = ws.capacityId ? getCapacityById(ws.capacityId) : null;
         return {
           id: ws.id,
@@ -235,6 +230,7 @@ export function DashboardPage() {
     tenantGrade,
     atRiskCount,
     getCapacityById,
+    namingPattern,
   ]);
 
   const refreshLabel = lastRefresh

--- a/src/pages/ReportPage.tsx
+++ b/src/pages/ReportPage.tsx
@@ -7,13 +7,13 @@ import { useSecurityStore } from '@/store/securityStore';
 import { useTenantSettingsStore } from '@/store/tenantSettingsStore';
 import { useWidelySharedStore } from '@/store/widelySharedStore';
 import { useActivityStore } from '@/store/activityStore';
-import { calculateWorkspaceHealth, type HealthGrade } from '@/utils/healthScore';
+import { calculateWorkspaceHealth, getGrade, type HealthGrade } from '@/utils/healthScore';
+import { useNamingPattern } from '@/hooks/useNamingPattern';
 import { computeSecurityPosture } from '@/utils/securityFindings';
 import type { UserSummary } from '@/utils/effectiveAccess';
 import { deriveRiskySettings } from '@/utils/tenantSettingRisks';
 import { assembleReportData } from '@/utils/reportData';
 import { generateExecutiveSummary } from '@/utils/reportSummary';
-import { GRADE_THRESHOLDS } from '@/utils/constants';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { ReportCover } from '@/components/report/ReportCover';
 import { ExecutiveSummarySection } from '@/components/report/ExecutiveSummarySection';
@@ -24,14 +24,6 @@ import { WidelySharedSection } from '@/components/report/WidelySharedSection';
 import { GhostWorkspacesSection } from '@/components/report/GhostWorkspacesSection';
 import { RecommendationsSection } from '@/components/report/RecommendationsSection';
 
-function getGrade(score: number): HealthGrade {
-  if (score >= GRADE_THRESHOLDS.A) return 'A';
-  if (score >= GRADE_THRESHOLDS.B) return 'B';
-  if (score >= GRADE_THRESHOLDS.C) return 'C';
-  if (score >= GRADE_THRESHOLDS.D) return 'D';
-  return 'F';
-}
-
 export function ReportPage() {
   useDocumentTitle('Governance Report');
   const { workspaces, allItemsByWorkspace } = useWorkspaceStore();
@@ -40,13 +32,15 @@ export function ReportPage() {
   const { artifacts, error: widelySharedError } = useWidelySharedStore();
   const { ghostWorkspaces, lastFetchedAt } = useActivityStore();
 
+  const namingPattern = useNamingPattern();
+
   // --- Health ---
   const healthMap = useMemo(
     () =>
       new Map(
-        workspaces.map((ws) => [ws.id, calculateWorkspaceHealth(ws, allItemsByWorkspace[ws.id] ?? [])]),
+        workspaces.map((ws) => [ws.id, calculateWorkspaceHealth(ws, allItemsByWorkspace[ws.id] ?? [], namingPattern)]),
       ),
-    [workspaces, allItemsByWorkspace],
+    [workspaces, allItemsByWorkspace, namingPattern],
   );
 
   const { tenantScore, tenantGrade } = useMemo(() => {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -16,13 +16,16 @@ import { useUiStore } from '@/store/uiStore';
 import { isEffectiveDemoMode, msalInstance } from '@/auth/AuthProvider';
 import {
   DEFAULT_NAMING_PATTERN_STRING,
-  DEFAULT_STALE_THRESHOLD_DAYS,
   HEALTH_SCORE_WEIGHTS,
   HEALTH_SCORE_MAX,
   APP_VERSION,
   GRAPH_SCOPES,
   GITHUB_URL,
 } from '@/utils/constants';
+import {
+  useHealthConfigStore,
+  isValidPattern,
+} from '@/store/healthConfigStore';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 
 // --- Auth Status Section ---
@@ -241,8 +244,12 @@ function PermissionsSection() {
 // --- Health Config Section ---
 
 function HealthConfigSection() {
-  const [namingPattern, setNamingPattern] = useState(DEFAULT_NAMING_PATTERN_STRING);
-  const [staleThreshold, setStaleThreshold] = useState(DEFAULT_STALE_THRESHOLD_DAYS);
+  const namingPattern = useHealthConfigStore((s) => s.namingPattern);
+  const setNamingPattern = useHealthConfigStore((s) => s.setNamingPattern);
+  const reset = useHealthConfigStore((s) => s.reset);
+
+  const isDefault = namingPattern === DEFAULT_NAMING_PATTERN_STRING;
+  const patternValid = isValidPattern(namingPattern);
 
   return (
     <div className="rounded-xl border border-[var(--m-border)] bg-[var(--m-bg)]">
@@ -254,38 +261,40 @@ function HealthConfigSection() {
       </div>
       <div className="space-y-4 px-5 py-4">
         <div>
-          <label className="mb-1.5 block text-sm font-medium text-[var(--m-text-secondary)]">
-            Naming Convention Pattern
-          </label>
+          <div className="mb-1.5 flex items-center justify-between gap-3">
+            <label htmlFor="naming-pattern" className="block text-sm font-medium text-[var(--m-text-secondary)]">
+              Naming Convention Pattern
+            </label>
+            {!isDefault && (
+              <button
+                type="button"
+                onClick={reset}
+                className="-my-1 py-1 text-xs font-medium text-[var(--m-primary)] hover:underline"
+              >
+                Reset to default
+              </button>
+            )}
+          </div>
           <input
+            id="naming-pattern"
             type="text"
             value={namingPattern}
             onChange={(e) => setNamingPattern(e.target.value)}
+            aria-invalid={!patternValid}
+            aria-describedby="naming-pattern-help"
             className="w-full rounded-lg border border-[var(--m-border)] bg-[var(--m-bg)] px-3 py-2 font-mono text-sm text-[var(--m-text)]"
           />
-          <p className="mt-1 text-xs text-[var(--m-text-tertiary)]">
-            Regex pattern for workspace naming compliance ({HEALTH_SCORE_WEIGHTS.naming} pts).
-          </p>
-        </div>
-
-        <div>
-          <label className="mb-1.5 block text-sm font-medium text-[var(--m-text-secondary)]">
-            Stale Threshold (days)
-          </label>
-          <input
-            type="number"
-            min={7}
-            max={365}
-            value={staleThreshold}
-            onChange={(e) =>
-              setStaleThreshold(
-                Math.min(365, Math.max(7, Number(e.target.value))),
-              )
-            }
-            className="w-32 rounded-lg border border-[var(--m-border)] bg-[var(--m-bg)] px-3 py-2 text-sm text-[var(--m-text)]"
-          />
-          <p className="mt-1 text-xs text-[var(--m-text-tertiary)]">
-            Items not modified within this period are considered stale. This is informational and does not affect the health score.
+          <p id="naming-pattern-help" className="mt-1 text-xs text-[var(--m-text-tertiary)]">
+            {patternValid ? (
+              <>
+                Regex pattern for workspace naming compliance ({HEALTH_SCORE_WEIGHTS.naming} pts).
+                {!isDefault && ' Scores across the app use this pattern.'}
+              </>
+            ) : (
+              <span className="font-medium text-[var(--m-error)]">
+                Not a valid regular expression. Scoring falls back to the default pattern until this is fixed.
+              </span>
+            )}
           </p>
         </div>
 

--- a/src/pages/WorkspaceDetailPage.tsx
+++ b/src/pages/WorkspaceDetailPage.tsx
@@ -18,6 +18,7 @@ import { StateBadge } from '@/components/shared/StateBadge';
 import { HealthBadge } from '@/components/workspace/HealthBadge';
 import { HealthDetail } from '@/components/workspace/HealthDetail';
 import { calculateWorkspaceHealth } from '@/utils/healthScore';
+import { useNamingPattern } from '@/hooks/useNamingPattern';
 import type { Item } from '@/api/types/item';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 
@@ -80,10 +81,12 @@ export function WorkspaceDetailPage() {
     ? getCapacityById(workspace.capacityId)
     : undefined;
 
+  const namingPattern = useNamingPattern();
+
   const healthScore = useMemo(() => {
     if (!workspace) return null;
-    return calculateWorkspaceHealth(workspace, items);
-  }, [workspace, items]);
+    return calculateWorkspaceHealth(workspace, items, namingPattern);
+  }, [workspace, items, namingPattern]);
 
   const columns: Column<Item>[] = [
     {

--- a/src/pages/WorkspacesPage.tsx
+++ b/src/pages/WorkspacesPage.tsx
@@ -10,6 +10,7 @@ import { StateBadge } from '@/components/shared/StateBadge';
 import { ExportButton } from '@/components/shared/ExportButton';
 import { HealthBadge } from '@/components/workspace/HealthBadge';
 import { calculateWorkspaceHealth, type HealthScore } from '@/utils/healthScore';
+import { useNamingPattern } from '@/hooks/useNamingPattern';
 import { exportToCSV } from '@/utils/export';
 import { getCurrentUserEmail } from '@/auth/currentUser';
 import { getMyWorkspaceIds } from '@/utils/myWorkspaces';
@@ -44,16 +45,18 @@ export function WorkspacesPage() {
     populateDemoUsers();
   }, [fetchWorkspaces, fetchCapacities, fetchAllItems, populateDemoUsers]);
 
+  const namingPattern = useNamingPattern();
+
   // Health per workspace, from the same scorer the dashboard and detail pages use.
   const healthMap = useMemo(
     () =>
       new Map<string, HealthScore>(
         workspaces.map((w) => [
           w.id,
-          calculateWorkspaceHealth(w, allItemsByWorkspace[w.id] ?? []),
+          calculateWorkspaceHealth(w, allItemsByWorkspace[w.id] ?? [], namingPattern),
         ]),
       ),
-    [workspaces, allItemsByWorkspace],
+    [workspaces, allItemsByWorkspace, namingPattern],
   );
 
   const myWorkspaceIds = useMemo(

--- a/src/store/__tests__/healthConfigStore.test.ts
+++ b/src/store/__tests__/healthConfigStore.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  useHealthConfigStore,
+  compileNamingPattern,
+  isValidPattern,
+} from '@/store/healthConfigStore';
+import {
+  DEFAULT_NAMING_PATTERN,
+  DEFAULT_NAMING_PATTERN_STRING,
+} from '@/utils/constants';
+
+describe('compileNamingPattern', () => {
+  it('compiles a valid pattern', () => {
+    const re = compileNamingPattern('^PRD-');
+    expect(re.test('PRD-Sales')).toBe(true);
+    expect(re.test('Sales')).toBe(false);
+  });
+
+  it('falls back to the default when the pattern is not valid regex', () => {
+    // An unclosed group is what a half-typed pattern looks like. Without the
+    // guard this throws inside render and blanks every page that scores.
+    expect(() => compileNamingPattern('^(PRD')).not.toThrow();
+    expect(compileNamingPattern('^(PRD').source).toBe(DEFAULT_NAMING_PATTERN.source);
+  });
+
+  it('flags validity so Settings can warn before the fallback happens', () => {
+    expect(isValidPattern('^PRD-')).toBe(true);
+    expect(isValidPattern('^(PRD')).toBe(false);
+  });
+});
+
+describe('useHealthConfigStore', () => {
+  beforeEach(() => {
+    useHealthConfigStore.getState().reset();
+  });
+
+  it('defaults to the shipped naming pattern', () => {
+    expect(useHealthConfigStore.getState().namingPattern).toBe(
+      DEFAULT_NAMING_PATTERN_STRING,
+    );
+  });
+
+  it('stores a custom pattern and resets back to the default', () => {
+    useHealthConfigStore.getState().setNamingPattern('^PRD-');
+    expect(useHealthConfigStore.getState().namingPattern).toBe('^PRD-');
+
+    useHealthConfigStore.getState().reset();
+    expect(useHealthConfigStore.getState().namingPattern).toBe(
+      DEFAULT_NAMING_PATTERN_STRING,
+    );
+  });
+});

--- a/src/store/healthConfigStore.ts
+++ b/src/store/healthConfigStore.ts
@@ -1,0 +1,47 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import {
+  DEFAULT_NAMING_PATTERN,
+  DEFAULT_NAMING_PATTERN_STRING,
+} from '@/utils/constants';
+
+interface HealthConfigState {
+  namingPattern: string;
+  setNamingPattern: (pattern: string) => void;
+  reset: () => void;
+}
+
+export const useHealthConfigStore = create<HealthConfigState>()(
+  persist(
+    (set) => ({
+      namingPattern: DEFAULT_NAMING_PATTERN_STRING,
+      setNamingPattern: (namingPattern: string) => set({ namingPattern }),
+      reset: () => set({ namingPattern: DEFAULT_NAMING_PATTERN_STRING }),
+    }),
+    { name: 'fabric-lens-health-config' },
+  ),
+);
+
+/** True when the pattern compiles. Settings uses this to flag bad input
+ *  before it silently falls back. */
+export function isValidPattern(pattern: string): boolean {
+  try {
+    new RegExp(pattern);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Compiles the stored pattern, falling back to the default when the user has
+ *  typed something that is not a valid regex. The value is persisted from
+ *  localStorage and reaches `new RegExp` directly, so it is untrusted input:
+ *  without this guard one bad character blanks every page that scores a
+ *  workspace. */
+export function compileNamingPattern(pattern: string): RegExp {
+  try {
+    return new RegExp(pattern);
+  } catch {
+    return DEFAULT_NAMING_PATTERN;
+  }
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -230,13 +230,18 @@ export const GRADE_THRESHOLDS = {
   D: 50,
 } as const;
 
-/** Health grade hex colors — used for Recharts <Cell fill> where CSS vars cannot be used. */
+/** Health grade colors for inline `fill` / `backgroundColor`, where a Tailwind
+ *  class cannot reach. These are `var()` references rather than hex on purpose:
+ *  as literals they were a light-mode snapshot that never flipped, so the report
+ *  chips and the dashboard grade chart stayed light while every token-driven
+ *  chip beside them went dark. Recharts passes `var()` straight through to the
+ *  SVG attribute — the axis tick fill in DashboardPage already relies on it. */
 export const HEALTH_GRADE_COLORS = {
-  A: '#15803D',
-  B: '#4F46E5',
-  C: '#B45309',
-  D: '#C2410C',
-  F: '#B91C1C',
+  A: 'var(--health-a)',
+  B: 'var(--health-b)',
+  C: 'var(--health-c)',
+  D: 'var(--health-d)',
+  F: 'var(--health-f)',
 } as const;
 
 /** Maximum item count before a workspace is flagged as oversized. */

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -242,9 +242,6 @@ export const HEALTH_GRADE_COLORS = {
 /** Maximum item count before a workspace is flagged as oversized. */
 export const MAX_REASONABLE_ITEM_COUNT = 100;
 
-/** Default number of days after which items are considered stale. */
-export const DEFAULT_STALE_THRESHOLD_DAYS = 90;
-
 // -- Security --
 
 /** Number of Admin-role assignments before flagging a user as over-permissioned. */

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -236,7 +236,7 @@ export const HEALTH_GRADE_COLORS = {
   B: '#4F46E5',
   C: '#B45309',
   D: '#C2410C',
-  F: '#DC2626',
+  F: '#B91C1C',
 } as const;
 
 /** Maximum item count before a workspace is flagged as oversized. */

--- a/src/utils/healthScore.ts
+++ b/src/utils/healthScore.ts
@@ -25,7 +25,10 @@ export interface HealthScore {
   grade: HealthGrade;
 }
 
-function getGrade(percentage: number): HealthGrade {
+/** The one grade ladder. Health scores, the tenant roll-up, the report and the
+ *  security posture all read it, so a threshold moves everywhere at once or
+ *  nowhere. It was written out four times before. */
+export function getGrade(percentage: number): HealthGrade {
   if (percentage >= GRADE_THRESHOLDS.A) return 'A';
   if (percentage >= GRADE_THRESHOLDS.B) return 'B';
   if (percentage >= GRADE_THRESHOLDS.C) return 'C';

--- a/src/utils/securityFindings.ts
+++ b/src/utils/securityFindings.ts
@@ -6,9 +6,9 @@ import type { ResolvedGroup } from '@/api/types/admin';
 import type { UserSummary } from '@/utils/effectiveAccess';
 import {
   ADMIN_ROLE_WARNING_THRESHOLD,
-  GRADE_THRESHOLDS,
   ADMIN_ASSIGNMENT_PCT_THRESHOLD,
 } from '@/utils/constants';
+import { getGrade } from '@/utils/healthScore';
 
 export type FindingSeverity = 'critical' | 'warning' | 'info';
 
@@ -207,13 +207,10 @@ export interface SecurityPosture {
   checks: PostureCheck[];
 }
 
-function postureGrade(score: number): string {
-  if (score >= GRADE_THRESHOLDS.A) return 'A';
-  if (score >= GRADE_THRESHOLDS.B) return 'B';
-  if (score >= GRADE_THRESHOLDS.C) return 'C';
-  if (score >= GRADE_THRESHOLDS.D) return 'D';
-  return 'F';
-}
+/** Security posture deliberately shares the health grade ladder, so an A means
+ *  the same percentage on both scores. Splitting them would change shipped
+ *  security grades and is a product decision, not a refactor. */
+const postureGrade = getGrade;
 
 export function computeSecurityPosture(
   userSummaries: UserSummary[],


### PR DESCRIPTION
Six commits whose branch name stopped describing them four commits in. Released as v2.5.0; the
naming pattern is user visible, so this is a minor rather than a patch.

## The naming pattern was a dead control

Settings has a "Naming Convention Pattern" input. Its value lived in `useState`, nothing persisted
it, and all seven `calculateWorkspaceHealth` call sites omitted the third argument, so
`DEFAULT_NAMING_PATTERN` always won. A user could type a regex, watch it be accepted, and change
nothing. Same class of defect as the v1.4.0 My Workspaces filter.

It is now a persisted `healthConfigStore` (localStorage, the same pattern as `uiStore`), read through
`useNamingPattern()` by the six surfaces that score a workspace: Dashboard, Workspaces, workspace
detail, Report, ghost workspaces and the report cover. Reset to defaults is available, an invalid
regex falls back to the default rather than throwing, and a non-default pattern is stamped on the
exported report so a tuned score is never quietly passed off as the standard one.

`LandingPage` deliberately keeps the default. It is prerendered marketing and must not vary per
visitor.

The **Stale Threshold** input beside it was deleted rather than wired up: nothing read
`DEFAULT_STALE_THRESHOLD_DAYS`, so persisting it would have stored a number no code consumes.

Tunable weights and thresholds were considered and ruled out. `BENCHMARK_HEALTH_SCORE` (78) is a
fixed median the dashboard ring compares against, `reportData.ts` derives recoverable points from the
weights, and `/about` publishes the weights table. The grade has to stay a measurement rather than an
opinion for any of those to keep meaning what they say.

## Three item colours now clear AA

Pre-existing failures in light mode at badge size, measured against their own tint:

| family | before | after |
|---|---|---|
| `dashboard` | `#EA580C` 3.35 | `#BF310D` 5.40 |
| `warehouse` | `#0891B2` 3.54 | `#0E7490` 5.15 |
| `semantic-model` | `#DB2777` 4.21 | `#BE185D` 5.53 |

All 11 families pass in light mode now. Dark mode was never affected and is unchanged: the 400 weight
ramp on 15% tints already measured 6.49 and above.

`warehouse` and `semantic-model` took the Tailwind 700 step. `dashboard` could not: orange-700
`#C2410C` is already `--health-d` and `--m-warning`, and `--health-d-bg` is the same tint, so a D
grade badge and a Dashboard item badge would have rendered identically. `#BF310D` is hand-picked at
hue 12 and is the one non-Tailwind value in the palette, with the reason recorded beside it in
`index.css`. It also widened the gap to `report` from 5.5 degrees to 14.

These are colours already in production. `CHART_COLORS` and `--status-warning` still carry the three
old hexes, deliberately: different namespaces.

## Grade colours

Two copies of the F grade were still `#DC2626`, left behind when F was darkened to `#B91C1C` to clear
AA on its own tint. White on it goes from 4.83 to 6.47. The other four grades already matched.

The report chips and the dashboard chart held a light mode hex snapshot, so they stayed light in dark
mode. They reference the tokens now and follow the theme.

## Two /about scoring claims

Both were wrong where it is published and prerendered. The data layer check accepts only Lakehouse
and Warehouse, not Semantic Models, and the item count check passes at exactly 100 rather than
failing there. The points column now derives from `HEALTH_SCORE_WEIGHTS` instead of being
hand-copied, which is what let it drift.

## Fourth docs:check

`npm run docs:check` now compares the DESIGN_GUIDE item palette's hex values and its stated family
count against `index.css`. That drift already happened once: v2.4.0 added four families and the guide
still listed eight the next day, while the design audit step sends every reviewer to that list. The
check skips cleanly in CI, where `.local/` does not exist, and it was watched go red against a
mutated value before being trusted.

`npm run verify` is green at every commit on the branch.
